### PR TITLE
Fix syntax in version_requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,11 +15,11 @@
     "dependencies": [
         {
             "name": "puppetlabs-apt",
-            "version_requirement": ">= 2.1.0  <3.0.0"
+            "version_requirement": ">= 2.1.0 < 3.0.0"
         },
         {
             "name": "puppetlabs-inifile",
-            "version_requirement": ">= 1.4.0 <2.0.0"
+            "version_requirement": ">= 1.4.0 < 2.0.0"
         }
     ],
     "operatingsystem_support": [


### PR DESCRIPTION
librarian-puppet 2.0.1 gives the following error without this fix:

    requirement.rb:100:in `parse': Illformed requirement [">= 2.1.0  <3.0.0"] (Gem::Requirement::BadRequirementError)