### PR TITLE
use $service_ensure for cassandra instead of always running

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class cassandra (
   if $package_ensure != 'absent'
   and $package_ensure != 'purged' {
     service { 'cassandra':
-      ensure  => running,
+      ensure  => $service_ensure,
       name    => $service_name,
       enable  => true,
       require => Package[$package_name],


### PR DESCRIPTION
Seems like this is an ok way to deal with this, since service_ensure was already defaulted to 'running', this should be no net change if previously unconfigured. for #93 