### PR TITLE
Allowing setting of local_interface for the datastax agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,13 @@ set as the stomp_interface setting in
 which connects the agent to an OpsCenter instance.
 Default value *undef*
 
+##### `local_interface`
+If the value is changed from the default of *undef* then this is what is
+set as the local_interface setting in
+**/var/lib/datastax-agent/conf/address.yaml**
+which is the address there the local cassandra will be contacted.
+Default value *undef*
+
 ### Class: cassandra::datastax_repo
 
 An optional class that will allow a suitable repository to be configured

--- a/manifests/datastax_agent.pp
+++ b/manifests/datastax_agent.pp
@@ -1,13 +1,15 @@
 # Install and configure the optional DataStax agent.
 class cassandra::datastax_agent (
-  $defaults_file   = '/etc/default/datastax-agent',
-  $java_home       = undef,
-  $package_ensure  = 'present',
-  $package_name    = 'datastax-agent',
-  $service_ensure  = 'running',
-  $service_enable  = true,
-  $service_name    = 'datastax-agent',
-  $stomp_interface = undef,
+  $defaults_file       = '/etc/default/datastax-agent',
+  $address_config_file = '/var/lib/datastax-agent/conf/address.yaml',
+  $java_home           = undef,
+  $package_ensure      = 'present',
+  $package_name        = 'datastax-agent',
+  $service_ensure      = 'running',
+  $service_enable      = true,
+  $service_name        = 'datastax-agent',
+  $stomp_interface     = undef,
+  $local_interface     = undef,
   ){
   package { $package_name:
     ensure  => $package_ensure,
@@ -23,11 +25,28 @@ class cassandra::datastax_agent (
 
   ini_setting { 'stomp_interface':
     ensure            => $ensure,
-    path              => '/var/lib/datastax-agent/conf/address.yaml',
+    path              => $address_config_file,
     section           => '',
     key_val_separator => ': ',
     setting           => 'stomp_interface',
     value             => $stomp_interface,
+    require           => Package[$package_name],
+    notify            => Service[$service_name]
+  }
+
+  if $local_interface != undef {
+    $ensure_local_interface = present
+  } else {
+    $ensure_local_interface = absent
+  }
+
+  ini_setting { 'local_interface':
+    ensure            => $ensure_local_interface,
+    path              => $address_config_file,
+    section           => '',
+    key_val_separator => ': ',
+    setting           => 'local_interface',
+    value             => $local_interface,
     require           => Package[$package_name],
     notify            => Service[$service_name]
   }

--- a/spec/classes/datastax_agent_spec.rb
+++ b/spec/classes/datastax_agent_spec.rb
@@ -5,7 +5,7 @@ describe 'cassandra::datastax_agent' do
   ] }
 
   context 'Test for cassandra::datastax_agent.' do
-    it { should have_resource_count(3) }
+    it { should have_resource_count(4) }
     it {
       should contain_class('cassandra::datastax_agent').only_with(
         'defaults_file'   => '/etc/default/datastax-agent',
@@ -16,6 +16,7 @@ describe 'cassandra::datastax_agent' do
         'service_enable'  => true,
         'service_name'    => 'datastax-agent',
         'stomp_interface' => nil,
+        'local_interface' => nil,
       )
     }
     it {
@@ -58,6 +59,25 @@ describe 'cassandra::datastax_agent' do
         'path'   => '/etc/default/datastax-agent',
         'value'  => '/usr/lib/jvm/java-8-oracle'
       )
+    }
+  end
+
+  context 'Test that local_interface can be set.' do
+    let :params do
+      {
+          :local_interface => '127.0.0.1'
+      }
+    end
+
+    it { should contain_ini_setting('local_interface').with_ensure('present') }
+    it {
+      should contain_ini_setting('local_interface').with_value('127.0.0.1')
+    }
+  end
+
+  context 'Test that local_interface can be ignored.' do
+    it {
+      should contain_ini_setting('local_interface').with_ensure('absent')
     }
   end
 end


### PR DESCRIPTION
I added the ability to set the local_interface in the datastax agent. This would be also a part of of this ticket https://github.com/locp/cassandra/issues/73.

Regards
Mike
