### PR TITLE
Add alias to cassandra::datastax_agent to tag the agent thru OpsCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1770,6 +1770,13 @@ set as the local_interface setting in
 which is the address there the local cassandra will be contacted.
 Default value *undef*
 
+##### `alias`
+If the value is changed from the default of *undef* then this is what is
+set as the alias setting in
+**/var/lib/datastax-agent/conf/address.yaml**
+which is the name the agent announces itself to OpsCenter as.
+Default value *undef*
+
 ### Class: cassandra::datastax_repo
 
 An optional class that will allow a suitable repository to be configured

--- a/manifests/datastax_agent.pp
+++ b/manifests/datastax_agent.pp
@@ -11,6 +11,7 @@ class cassandra::datastax_agent (
   $service_provider    = undef,
   $stomp_interface     = undef,
   $local_interface     = undef,
+  $alias               = undef,
   ){
   package { $package_name:
     ensure  => $package_ensure,
@@ -48,6 +49,23 @@ class cassandra::datastax_agent (
     key_val_separator => ': ',
     setting           => 'local_interface',
     value             => $local_interface,
+    require           => Package[$package_name],
+    notify            => Service[$service_name]
+  }
+
+  if $alias != undef {
+    $ensure_alias = present
+  } else {
+    $ensure_alias = absent
+  }
+
+  ini_setting { 'alias':
+    ensure            => $ensure_alias,
+    path              => $address_config_file,
+    section           => '',
+    key_val_separator => ': ',
+    setting           => 'alias',
+    value             => $alias,
     require           => Package[$package_name],
     notify            => Service[$service_name]
   }

--- a/spec/classes/datastax_agent_spec.rb
+++ b/spec/classes/datastax_agent_spec.rb
@@ -5,7 +5,7 @@ describe 'cassandra::datastax_agent' do
   ] }
 
   context 'Test for cassandra::datastax_agent.' do
-    it { should have_resource_count(4) }
+    it { should have_resource_count(5) }
     it {
       should contain_class('cassandra::datastax_agent').only_with(
         'defaults_file'    => '/etc/default/datastax-agent',
@@ -25,6 +25,25 @@ describe 'cassandra::datastax_agent' do
     }
     it {
       should contain_service('datastax-agent')
+    }
+  end
+
+  context 'Test that alias can be set.' do
+    let :params do
+      {
+          :alias => 'node-1'
+      }
+    end
+
+    it { should contain_ini_setting('alias').with_ensure('present') }
+    it {
+      should contain_ini_setting('alias').with_value('node-1')
+    }
+  end
+
+  context 'Test that alias can be ignored.' do
+    it {
+      should contain_ini_setting('alias').with_ensure('absent')
     }
   end
 
@@ -81,4 +100,5 @@ describe 'cassandra::datastax_agent' do
       should contain_ini_setting('local_interface').with_ensure('absent')
     }
   end
+
 end


### PR DESCRIPTION
Nodes without an alias set show up as unknown in various OpsCenter pages, this commit fixes that problem.