### PR TITLE
Allowing setting of async_pool_size and async_queue_size for the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1791,6 +1791,20 @@ set as the local_interface setting in
 which is the address there the local cassandra will be contacted.
 Default value *undef*
 
+##### `async_pool_size`
+If the value is changed from the default of *undef* then this is what is
+set as the async_pool_size setting in
+**/var/lib/datastax-agent/conf/address.yaml**
+which is the pool size to use for async operations to cassandra.
+Default value *undef*
+
+##### `async_queue_size`
+If the value is changed from the default of *undef* then this is what is
+set as the async_queue_size setting in
+**/var/lib/datastax-agent/conf/address.yaml**
+which is the maximum number of queued cassandra operations.
+Default value *undef*
+
 ### Class: cassandra::datastax_repo
 
 An optional class that will allow a suitable repository to be configured

--- a/manifests/datastax_agent.pp
+++ b/manifests/datastax_agent.pp
@@ -12,6 +12,8 @@ class cassandra::datastax_agent (
   $stomp_interface     = undef,
   $local_interface     = undef,
   $agent_alias         = undef,
+  $async_pool_size     = undef,
+  $async_queue_size    = undef,
   ){
   package { $package_name:
     ensure  => $package_ensure,
@@ -68,6 +70,32 @@ class cassandra::datastax_agent (
     value             => $agent_alias,
     require           => Package[$package_name],
     notify            => Service[$service_name]
+  }
+
+  if $async_pool_size != undef {
+    ini_setting { 'async_pool_size':
+      ensure            => present,
+      path              => $address_config_file,
+      section           => '',
+      key_val_separator => ': ',
+      setting           => 'async_pool_size',
+      value             => $async_pool_size,
+      require           => Package[$package_name],
+      notify            => Service[$service_name]
+    }
+  }
+
+  if $async_queue_size != undef {
+    ini_setting { 'async_queue_size':
+      ensure            => present,
+      path              => $address_config_file,
+      section           => '',
+      key_val_separator => ': ',
+      setting           => 'async_queue_size',
+      value             => $async_queue_size,
+      require           => Package[$package_name],
+      notify            => Service[$service_name]
+    }
   }
 
   if $java_home != undef {

--- a/spec/classes/datastax_agent_spec.rb
+++ b/spec/classes/datastax_agent_spec.rb
@@ -101,4 +101,30 @@ describe 'cassandra::datastax_agent' do
     }
   end
 
+  context 'Test that async_pool_size can be set.' do
+    let :params do
+      {
+         :async_pool_size => '20000'
+      }
+    end
+
+    it { should contain_ini_setting('async_pool_size').with_ensure('present') }
+    it {
+      should contain_ini_setting('async_pool_size').with_value('20000')
+    }
+  end
+
+  context 'Test that async_queue_size can be set.' do
+    let :params do
+      {
+         :async_queue_size => '20000'
+      }
+    end
+
+    it { should contain_ini_setting('async_queue_size').with_ensure('present') }
+    it {
+      should contain_ini_setting('async_queue_size').with_value('20000')
+    }
+  end
+
 end


### PR DESCRIPTION
Hi,
i added options to set the async_pool_size and async_queue_size. I know you want to optimize the structure but maybe yiou can still merge it in the current branch :)

Regards
Mike