### PR TITLE
Feature/opscenter orbited longpoll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ spec/fixtures/
 .vagrant/
 vendor/
 log/
+.project

--- a/README.md
+++ b/README.md
@@ -1785,6 +1785,12 @@ http://docs.datastax.com/en/opscenter/5.2/opsc/configure/opscConfigProps_r.html
 for more details.  A value of *undef* will ensure the setting is not present
 in the file.  Default value *undef*
 
+#### `orbited_longpoll`
+This sets the orbited_longpoll setting in the labs section of the OpsCenter 
+configuration file. See labs http://docs.datastax.com/en/opscenter/5.2/opsc/troubleshooting/opscTroubleshootingZeroNodes.html
+for more details.  A value of *undef* will ensure the setting is not present in 
+the file. Default value *undef*
+
 ##### `ldap_admin_group_name`
 This sets the admin_group_name setting in the ldap section of the
 OpsCenter configuration file.  See

--- a/manifests/opscenter.pp
+++ b/manifests/opscenter.pp
@@ -90,6 +90,7 @@ class cassandra::opscenter (
     $logging_log_path                               = undef,
     $logging_max_rotate                             = undef,
     $logging_resource_usage_interval                = undef,
+    $orbited_longpoll                               = undef,
     $repair_service_alert_on_repair_failure         = undef,
     $repair_service_cluster_stabilization_period    = undef,
     $repair_service_error_logging_window            = undef,
@@ -495,6 +496,13 @@ class cassandra::opscenter (
     section => 'hadoop',
     setting => 'base_job_tracker_proxy_port',
     value   => $hadoop_base_job_tracker_proxy_port
+  }
+  
+  cassandra::opscenter::setting { 'labs orbited_longpoll':
+    path    => $config_file,
+    section => 'labs',
+    setting => 'orbited_longpoll',
+    value   => $orbited_longpoll
   }
 
   cassandra::opscenter::setting { 'ldap admin_group_name':

--- a/spec/classes/opscenter_spec.rb
+++ b/spec/classes/opscenter_spec.rb
@@ -24,7 +24,7 @@ describe 'cassandra::opscenter' do
       })
     }
 
-    it { should have_resource_count(252) }
+    it { should have_resource_count(254) }
 
     it {
       should contain_cassandra__opscenter__setting('agents agent_certfile')
@@ -224,6 +224,10 @@ describe 'cassandra::opscenter' do
 
     it {
       should contain_cassandra__opscenter__setting('hadoop base_job_tracker_proxy_port')
+    }
+    
+    it {
+          should contain_cassandra__opscenter__setting('labs orbited_longpoll')
     }
 
     it {


### PR DESCRIPTION
Was trawling through forks of the locp/cassandra project and came across this work that had been carried out by @jonen10.  It adds a new feature, has all the unit tests that are required and the documentation has been included as well.  In fact, it meets all of our requirements for a pull request.

Assuming that the author has no objections (I have asked at https://github.com/jonen10/cassandra/commit/222c48915a7cc969d9a621810528b96ced160306) I will get this into a minor release.