### PR TITLE
Added opscenter ldap option group_search_filter_with_dn

### DIFF
--- a/README.md
+++ b/README.md
@@ -2480,7 +2480,16 @@ for more details.  A value of *undef* will ensure the setting is not present
 in the file.  Default value *undef*
 
 ##### `ldap_group_search_filter`
+Is deprecated use `ldap_group_search_filter_with_dn` instead.
+
 This sets the group_search_filter setting in the ldap section of the
+OpsCenter configuration file.  See
+http://docs.datastax.com/en/opscenter/5.2/opsc/configure/opscConfigProps_r.html
+for more details.  A value of *undef* will ensure the setting is not present
+in the file.  Default value *undef*
+
+##### `ldap_group_search_filter_with_dn`
+This sets the group_search_filter_with_dn setting in the ldap section of the
 OpsCenter configuration file.  See
 http://docs.datastax.com/en/opscenter/5.2/opsc/configure/opscConfigProps_r.html
 for more details.  A value of *undef* will ensure the setting is not present

--- a/manifests/opscenter.pp
+++ b/manifests/opscenter.pp
@@ -67,6 +67,7 @@ class cassandra::opscenter (
     $ldap_group_name_attribute                      = undef,
     $ldap_group_search_base                         = undef,
     $ldap_group_search_filter                       = undef,
+    $ldap_group_search_filter_with_dn               = undef,
     $ldap_group_search_type                         = undef,
     $ldap_ldap_security                             = undef,
     $ldap_opt_referrals                             = undef,
@@ -592,6 +593,13 @@ class cassandra::opscenter (
     section => 'ldap',
     setting => 'group_search_filter',
     value   => $ldap_group_search_filter
+  }
+
+  cassandra::private::opscenter::setting { 'ldap group_search_filter_with_dn':
+    path    => $config_file,
+    section => 'ldap',
+    setting => 'group_search_filter_with_dn',
+    value   => $ldap_group_search_filter_with_dn
   }
 
   cassandra::private::opscenter::setting { 'ldap group_search_type':

--- a/spec/classes/opscenter_spec.rb
+++ b/spec/classes/opscenter_spec.rb
@@ -23,7 +23,7 @@ describe 'cassandra::opscenter' do
         service_systemd: true
       }
     end
-    it { should have_resource_count(256) }
+    it { should have_resource_count(258) }
 
     it do
       should contain_exec('opscenter_reload_systemctl').with(refreshonly: true)
@@ -43,7 +43,7 @@ describe 'cassandra::opscenter' do
         service_systemd: true
       }
     end
-    it { should have_resource_count(256) }
+    it { should have_resource_count(258) }
 
     it do
       should contain_exec('opscenter_reload_systemctl').with(refreshonly: true)
@@ -112,7 +112,7 @@ describe 'cassandra::opscenter' do
               'webserver_port'         => 8888)
     end
 
-    it { should have_resource_count(254) }
+    it { should have_resource_count(256) }
 
     it do
       should contain_cassandra__private__opscenter__setting('agents agent_certfile')
@@ -340,6 +340,10 @@ describe 'cassandra::opscenter' do
 
     it do
       should contain_cassandra__private__opscenter__setting('ldap group_search_filter')
+    end
+
+    it do
+      should contain_cassandra__private__opscenter__setting('ldap group_search_filter_with_dn')
     end
 
     it do

--- a/spec/defines/private/opscenter/setting_spec.rb
+++ b/spec/defines/private/opscenter/setting_spec.rb
@@ -1039,6 +1039,24 @@ describe 'cassandra::private::opscenter::setting' do
     end
   end
 
+  context 'ldap group_search_filter_with_dn' do
+    let(:title) { 'ldap group_search_filter_with_dn' }
+    let :params do
+      {
+         path: '/path/to/file',
+         section: 'ldap',
+         setting: 'group_search_filter_with_dn'
+      }
+    end
+
+    it do
+      should contain_ini_setting('ldap group_search_filter_with_dn').with('ensure' => 'absent',
+                                                                          'path'    => '/path/to/file',
+                                                                          'section' => 'ldap',
+                                                                          'setting' => 'group_search_filter_with_dn')
+    end
+  end
+
   context 'ldap group_search_type' do
     let(:title) { 'ldap group_search_type' }
     let :params do


### PR DESCRIPTION
Added the option group_search_filter_with_dn for opscenter. This is the new variable for setting the ldap group search filter.