### PR TITLE
adding hints_directory for cassandra 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,14 @@ rate; if there are three, each will throttle to half of the maximum,
 since we expect two nodes to be delivering hints simultaneously.)
 Default value: '1024'
 
+##### `hints_directory`
+The Cassandra hints directory. A new feature in Cassandra 3.x+ stores
+hints in this directory. Leaving it unset will cause cassandra to use
+whatever the environmental value of $CASSANDRA_HOME/data/hints is set to.
+If you see cassandra is trying to write to /hints in the cassandra.log, 
+you should set this to a sane value.
+Default value: *undef*
+
 ##### `index_summary_capacity_in_mb`
 A fixed memory pool size in MB for for SSTable index summaries. If left
 empty, this will default to 5% of the heap size. If the memory usage of

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class cassandra (
   $file_cache_size_in_mb                                = undef,
   $hinted_handoff_enabled                               = true,
   $hinted_handoff_throttle_in_kb                        = 1024,
+  $hints_directory                                      = undef,
   $incremental_backups                                  = false,
   $index_summary_capacity_in_mb                         = '',
   $index_summary_resize_interval_in_minutes             = 60,

--- a/templates/cassandra.yaml.erb
+++ b/templates/cassandra.yaml.erb
@@ -49,6 +49,9 @@ hinted_handoff_throttle_in_kb: <%= @hinted_handoff_throttle_in_kb %>
 # Consider increasing this number when you have multi-dc deployments, since
 # cross-dc handoff tends to be slower
 max_hints_delivery_threads: <%= @max_hints_delivery_threads %>
+# Cassandra hints directory. 
+# (Default: $CASSANDRA_HOME/data/hints) Set directory where hints are stored.
+<% if @hints_directory != nil %>hints_directory: <%= @hints_directory %><% else %># hints_directory:<% end %>
 
 # Maximum throttle in KBs per second, total. This will be
 # reduced proportionally to the number of nodes in the cluster.


### PR DESCRIPTION
See the hints_directory section in the [cassandra.yaml manual](http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html) to see what this does. Right now when it's unset it tries to use /hints. This isn't wrong per se, but for folks going to cassandra 3.x, this needs to be specified. It's wrapped in an if statement in the erb so it won't be included so as not to break cassandra 2.x with unknown yaml if unspecified. 