### PR TITLE
Issue: Java version installed on Debian family by cassandra::java class #223

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -22,7 +22,7 @@ class cassandra::java (
   }
   
   if $::osfamily == 'Debian' {
-    $deb_major_release = $::facts['os']['release']['major']
+    $deb_major_release = $::os['release']['major']
     if $deb_major_release == '8' { $deb_release_name = 'jessie' }
     if $deb_major_release == '7' { $deb_release_name = 'wheezy' }
     file_line { 'Adding installation sources for OpenJDK 8':

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -22,9 +22,19 @@ class cassandra::java (
   }
   
   if $::osfamily = 'Debian' {
-    file_line { 'Adding installation sources for OpenJDK 8':
-      path => '/etc/apt/sources.list',  
-      line => 'deb http://http.debian.net/debian jessie-backports main',
+    $deb_major_release = $::facts['os']['release']['major']
+    if $deb_major_release = '8' { 
+      file_line { 'Adding jessie installation sources for OpenJDK 8':
+        path => '/etc/apt/sources.list',  
+        line => 'deb http://http.debian.net/debian jessie-backports main',
+      }
+    }
+    if $deb_major_release = '7' {
+      file_line { 'Adding wheezy installation sources for OpenJDK 8':
+        path  => '/etc/apt/sources.list',
+        line => 'deb http://http.debian.net/debian wheezy-backports main',
+      }
+    }
   }
 
   package { $package_name:

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -21,19 +21,13 @@ class cassandra::java (
     $version = $package_ensure
   }
   
-  if $::osfamily = 'Debian' {
+  if $::osfamily == 'Debian' {
     $deb_major_release = $::facts['os']['release']['major']
-    if $deb_major_release = '8' { 
-      file_line { 'Adding jessie installation sources for OpenJDK 8':
-        path => '/etc/apt/sources.list',  
-        line => 'deb http://http.debian.net/debian jessie-backports main',
-      }
-    }
-    if $deb_major_release = '7' {
-      file_line { 'Adding wheezy installation sources for OpenJDK 8':
-        path  => '/etc/apt/sources.list',
-        line => 'deb http://http.debian.net/debian wheezy-backports main',
-      }
+    if $deb_major_release == '8' { $deb_release_name = 'jessie' }
+    if $deb_major_release == '7' { $deb_release_name = 'wheezy' }
+    file_line { 'Adding installation sources for OpenJDK 8':
+      path  => '/etc/apt/sources.list',
+      line => "deb http://http.debian.net/debian $deb_release_name-backports main",
     }
   }
 

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -20,6 +20,12 @@ class cassandra::java (
   } else {
     $version = $package_ensure
   }
+  
+  if $::osfamily = 'Debian' {
+    file_line { 'Adding installation sources for OpenJDK 8':
+      path => '/etc/apt/sources.list',  
+      line => 'deb http://http.debian.net/debian jessie-backports main',
+  }
 
   package { $package_name:
     ensure => $version,

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -25,9 +25,17 @@ class cassandra::java (
     $deb_major_release = $::os['release']['major']
     if $deb_major_release == '8' { $deb_release_name = 'jessie' }
     if $deb_major_release == '7' { $deb_release_name = 'wheezy' }
+    if $deb_major_release == '6' { $deb_release_name = 'squeeze' }
     file_line { 'Adding installation sources for OpenJDK 8':
       path  => '/etc/apt/sources.list',
       line => "deb http://http.debian.net/debian $deb_release_name-backports main",
+    }
+    # This is horrible.
+    # See here: http://backports.debian.org/Instructions/#index3h2
+    # tl;dr - apt will not automatically install backports in debian
+    exec { 'Install Cassandra from backports':
+      path    => '/usr/sbin',
+      command => "apt-get -t $deb_release_name-backports install $package_name",
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class cassandra::params {
     'Debian': {
       $cassandra_pkg = 'cassandra'
       $config_path = '/etc/cassandra'
-      $java_package = 'openjdk-7-jre-headless'
+      $java_package = 'openjdk-8-jre-headless'
       $jna_package_name = 'libjna-java'
       $optutils_package_name = 'cassandra-tools'
       $systemctl = '/bin/systemctl'

--- a/spec/acceptance/cassandra_spec.rb
+++ b/spec/acceptance/cassandra_spec.rb
@@ -522,86 +522,81 @@ describe 'cassandra class' do
     end
   end
 
-  ###########################################################################
-  # Disabling this code for now as seem to be hitting a Red Hat affecting
-  # equivalent of CASSANDRA-10525 and on Debian, the cassandra::java class
-  # installs openjdk-7-jre-headless and Java 8u40 is required.
-  ###########################################################################
-  # cassandra_uninstall22_pp = <<-EOS
-  #   if $::osfamily == 'RedHat' {
-  #       $cassandra_optutils_package = 'cassandra22-tools'
-  #       $cassandra_package = 'cassandra22'
-  #   } else {
-  #       $cassandra_optutils_package = 'cassandra-tools'
-  #       $cassandra_package = 'cassandra'
-  #   }
-  #
-  #   package { $cassandra_optutils_package:
-  #     ensure => absent
-  #   } ->
-  #   package { $cassandra_package:
-  #     ensure => absent
-  #   }
-  # EOS
-  #
-  # cassandra_upgrade30_pp = <<-EOS
-  #   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 7 {
-  #       $service_systemd = true
-  #   } elsif $::operatingsystem == 'Debian'
-  #     and $::operatingsystemmajrelease == 8 {
-  #       $service_systemd = true
-  #   } else {
-  #       $service_systemd = false
-  #   }
-  #
-  #   if $::osfamily == 'RedHat' {
-  #       $cassandra_optutils_package = 'cassandra30-tools'
-  #       $cassandra_package = 'cassandra30'
-  #       $version = '3.0.3-1'
-  #   } else {
-  #       $cassandra_optutils_package = 'cassandra-tools'
-  #       $cassandra_package = 'cassandra'
-  #       $version = '3.0.3'
-  #   }
-  #
-  #   class { 'cassandra':
-  #     cassandra_9822              => true,
-  #     commitlog_directory_mode    => '0770',
-  #     data_file_directories_mode  => '0770',
-  #     listen_interface            => 'lo',
-  #     package_ensure              => $version,
-  #     package_name                => $cassandra_package,
-  #     rpc_interface               => 'lo',
-  #     saved_caches_directory_mode => '0770',
-  #     service_systemd             => $service_systemd
-  #   }
-  #
-  #   class { 'cassandra::optutils':
-  #     ensure       => $version,
-  #     package_name => $cassandra_optutils_package,
-  #     require      => Class['cassandra']
-  #   }
-  # EOS
-  #
-  # describe '########### Uninstall Cassandra 2.2.' do
-  #   it 'should work with no errors' do
-  #     apply_manifest(cassandra_uninstall22_pp, catch_failures: true)
-  #   end
-  # end
-  # describe '########### Cassandra 3.0 installation.' do
-  #   it 'should work with no errors' do
-  #     apply_manifest(cassandra_upgrade30_pp, catch_failures: true)
-  #   end
-  #   it 'check code is idempotent' do
-  #     expect(apply_manifest(cassandra_upgrade30_pp,
-  #                           catch_failures: true).exit_code).to be_zero
-  #   end
-  # end
-  #
-  # describe service('cassandra') do
-  #   it { is_expected.to be_running }
-  #   it { is_expected.to be_enabled }
-  # end
+   cassandra_uninstall22_pp = <<-EOS
+     if $::osfamily == 'RedHat' {
+         $cassandra_optutils_package = 'cassandra22-tools'
+         $cassandra_package = 'cassandra22'
+     } else {
+         $cassandra_optutils_package = 'cassandra-tools'
+         $cassandra_package = 'cassandra'
+     }
+  
+     package { $cassandra_optutils_package:
+       ensure => absent
+     } ->
+     package { $cassandra_package:
+       ensure => absent
+     }
+   EOS
+  
+   cassandra_upgrade30_pp = <<-EOS
+     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 7 {
+         $service_systemd = true
+     } elsif $::operatingsystem == 'Debian'
+       and $::operatingsystemmajrelease == 8 {
+         $service_systemd = true
+     } else {
+         $service_systemd = false
+     }
+  
+     if $::osfamily == 'RedHat' {
+         $cassandra_optutils_package = 'cassandra30-tools'
+         $cassandra_package = 'cassandra30'
+         $version = '3.0.3-1'
+     } else {
+         $cassandra_optutils_package = 'cassandra-tools'
+         $cassandra_package = 'cassandra'
+         $version = '3.0.3'
+      }
+  
+     class { 'cassandra':
+       cassandra_9822              => true,
+       commitlog_directory_mode    => '0770',
+       data_file_directories_mode  => '0770',
+       listen_interface            => 'lo',
+       package_ensure              => $version,
+       package_name                => $cassandra_package,
+       rpc_interface               => 'lo',
+       saved_caches_directory_mode => '0770',
+       service_systemd             => $service_systemd
+     }
+  
+     class { 'cassandra::optutils':
+       ensure       => $version,
+       package_name => $cassandra_optutils_package,
+       require      => Class['cassandra']
+     }
+   EOS
+  
+   describe '########### Uninstall Cassandra 2.2.' do
+     it 'should work with no errors' do
+       apply_manifest(cassandra_uninstall22_pp, catch_failures: true)
+     end
+   end
+   describe '########### Cassandra 3.0 installation.' do
+     it 'should work with no errors' do
+       apply_manifest(cassandra_upgrade30_pp, catch_failures: true)
+     end
+     it 'check code is idempotent' do
+       expect(apply_manifest(cassandra_upgrade30_pp,
+                             catch_failures: true).exit_code).to be_zero
+     end
+    end
+  
+   describe service('cassandra') do
+     it { is_expected.to be_running }
+     it { is_expected.to be_enabled }
+   end
 
   check_against_previous_version_pp = <<-EOS
     class { 'cassandra':

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -42,7 +42,7 @@ describe 'cassandra::java' do
     end
 
     it { should contain_class('cassandra::java') }
-    it { should contain_package('openjdk-7-jre-headless') }
+    it { should contain_package('openjdk-8-jre-headless') }
     it { should contain_package('libjna-java') }
     it { should have_resource_count(2) }
   end
@@ -60,7 +60,7 @@ describe 'cassandra::java' do
     end
 
     # rubocop:disable Metrics/LineLength
-    it { should contain_package('openjdk-7-jre-headless').with_ensure('2.1.13') }
+    it { should contain_package('openjdk-8-jre-headless').with_ensure('2.1.13') }
     # rubocop:enable Metrics/LineLength
   end
 


### PR DESCRIPTION
We're a fedora shop so I did this pretty much blindly. I believe Puppet will gracefully handle the installation of openjdk if the appropriate repo is added to the debian sources.list file. Lets see if this passes tests.