### PR TITLE
#232 - add ordering to service definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -276,11 +276,11 @@ class cassandra (
   if $package_ensure != 'absent' and $package_ensure != 'purged' {
     if $service_refresh {
       service { 'cassandra':
-        after     => File[ "$config_path/$snitch_properties_file" ],
         ensure    => $service_ensure,
         name      => $service_name,
         enable    => $service_enable,
         subscribe => [
+	  File[$config_path/$snitch_properties_file],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],
@@ -292,10 +292,19 @@ class cassandra (
       }
     } else {
       service { 'cassandra':
-        after  => File[ "$config_path/$snitch_properties_file" ],
-        ensure => $service_ensure,
-        name   => $service_name,
-        enable => $service_enable,
+        ensure  => $service_ensure,
+        name    => $service_name,
+        enable  => $service_enable,
+        require => [
+          File[$config_path/$snitch_properties_file],
+          File[$commitlog_directory],
+          File[$config_file],
+          File[$data_file_directories],
+          File[$saved_caches_directory],
+          Ini_setting['rackdc.properties.dc'],
+          Ini_setting['rackdc.properties.rack'],
+          Package['cassandra'],
+        ],
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -274,7 +274,7 @@ class cassandra (
   }
 
   if $package_ensure != 'absent' and $package_ensure != 'purged' {
-    if $service_refresh {
+    if $service_refresh and defined(Package[ $package_name ]) {
       service { 'cassandra':
         ensure    => $service_ensure,
         name      => $service_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -289,7 +289,6 @@ class cassandra (
           Ini_setting['rackdc.properties.rack'],
           Package['cassandra'],
         ],
-      })
     } else {
       service { 'cassandra':
         ensure => $service_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,7 +280,6 @@ class cassandra (
         name      => $service_name,
         enable    => $service_enable,
         subscribe => [
-	  File[$dc_rack_properties_file],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],
@@ -296,7 +295,6 @@ class cassandra (
         name    => $service_name,
         enable  => $service_enable,
         require => [
-          File[$dc_rack_properties_file],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,6 +292,7 @@ class cassandra (
       }
     } else {
       service { 'cassandra':
+        after  => File[ "$config_path/$snitch_properties_file" ],
         ensure => $service_ensure,
         name   => $service_name,
         enable => $service_enable,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -289,6 +289,7 @@ class cassandra (
           Ini_setting['rackdc.properties.rack'],
           Package['cassandra'],
         ],
+      }
     } else {
       service { 'cassandra':
         ensure => $service_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,7 +280,7 @@ class cassandra (
         name      => $service_name,
         enable    => $service_enable,
         subscribe => [
-	  File[$config_path/$snitch_properties_file],
+	  File[$dc_rack_properties_file],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],
@@ -296,7 +296,7 @@ class cassandra (
         name    => $service_name,
         enable  => $service_enable,
         require => [
-          File["$config_path/$snitch_properties_file"],
+          File[$dc_rack_properties_file],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -296,7 +296,7 @@ class cassandra (
         name    => $service_name,
         enable  => $service_enable,
         require => [
-          File[$config_path/$snitch_properties_file],
+          File["$config_path/$snitch_properties_file"],
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -274,8 +274,8 @@ class cassandra (
   }
 
   if $package_ensure != 'absent' and $package_ensure != 'purged' {
-    if $service_refresh and defined(Package[ $package_name ]) {
-      service { 'cassandra':
+    if $service_refresh {
+      ensure_resource('service', 'cassandra', {
         ensure    => $service_ensure,
         name      => $service_name,
         enable    => $service_enable,
@@ -288,7 +288,7 @@ class cassandra (
           Ini_setting['rackdc.properties.rack'],
           Package['cassandra'],
         ],
-      }
+      })
     } else {
       service { 'cassandra':
         ensure => $service_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -275,7 +275,8 @@ class cassandra (
 
   if $package_ensure != 'absent' and $package_ensure != 'purged' {
     if $service_refresh {
-      ensure_resource('service', 'cassandra', {
+      service { 'cassandra':
+        after     => File[ "$config_path/$snitch_properties_file" ],
         ensure    => $service_ensure,
         name      => $service_name,
         enable    => $service_enable,


### PR DESCRIPTION
Added requires to the service definition so that the module would work through the configuration files before trying to start the service. This ensures that upgrades go smoothly and the templates are all processed before the initial start also.