### PR TITLE
adding support for mmap

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,7 @@ class cassandra (
   $data_file_directories_mode                           = '0750',
   $dc                                                   = 'DC1',
   $dc_suffix                                            = undef,
+  $disk_access_mode                                     = undef,
   $disk_failure_policy                                  = 'stop',
   $dynamic_snitch_badness_threshold                     = 0.1,
   $dynamic_snitch_reset_interval_in_ms                  = 600000,

--- a/templates/cassandra20.yaml.erb
+++ b/templates/cassandra20.yaml.erb
@@ -729,6 +729,11 @@ inter_dc_tcp_nodelay: <%= @inter_dc_tcp_nodelay %>
 # (non-seed) nodes automatically migrate the right data to themselves. When
 # initializing a fresh cluster without data, add auto_bootstrap: false.
 <% if @auto_bootstrap != nil %>auto_bootstrap: <%= @auto_bootstrap %><% else %>#auto_bootstrap: true<% end %>
+
+# Disk access mode set to mmap - http://www.datastax.com/dev/blog/cassandra-and-windows-past-present-and-future
+# tl;dr - don't enable in windows or 32bit Linux.
+# This is a default in 2.1+ but not enabled in 2.0. It works in 2.0.
+<% if @disk_access_mode != nil %>disk_access_mode: <%= @disk_access_mode %><% else %># disk_access_mode: mmap<% end %>
 <% if !@additional_lines.empty? -%>
 
 <% @additional_lines.each do |additional_line| -%>


### PR DESCRIPTION
Tested in 2.0.11 - trade memory for disk performance in cassandra 2.0.XX. The default will be disabled (like it ships out of box) but users looking to toggle this will have the ability to do so.