### PR TITLE
additions for managing java temp_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2156,6 +2156,18 @@ The name of the Java package to be installed.
 Default value java-1.8.0-openjdk-headless on Red Hat openjdk-7-jre-headless
 on Debian.
 
+##### `temp_directory`
+If supplied, this will be a path for the module to manage which is used as a
+temp directory. This is to workaround problems cassandra has with `noexec` 
+being set on hardened distributions. 
+
+Typically you need to set this if you see something similar in the logs:
+```ERROR 17:49:12 Error in ThreadPoolExecutor
+java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.Native
+    at org.apache.cassandra.utils.memory.MemoryUtil.allocate(MemoryUtil.java:97) ~[apache-cassandra-3.0.8.jar:3.0.8]
+    at org.apache.cassandra.io.util.Memory.<init>(Memory.java:74) ~[apache-cassandra-3.0.8.jar:3.0.8]
+    ...```
+
 ##### `yumrepo`
 If supplied, this should be a hash of *yumrepo* resources that will be passed
 to the create_resources function.  This is ignored on non-Red Hat systems.

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -7,6 +7,7 @@ class cassandra::java (
   $jna_package_name = $::cassandra::params::jna_package_name,
   $package_ensure   = 'present',
   $package_name     = $::cassandra::params::java_package,
+  $temp_directory   = undef,
   $yumrepo          = undef,
   ) inherits cassandra::params {
   # Some horrific jiggerypokery until we can deprecate the ensure parameter.
@@ -63,5 +64,19 @@ class cassandra::java (
 
   package { $jna_package_name:
     ensure => $jna_ensure,
+  }
+
+  if $temp_directory != undef {
+    file { $temp_directory:
+      ensure => 'directory',
+      owner  => 'cassandra',
+      group  => 'cassandra',
+      mode   => '0750',
+    }
+    file_line { "Setting java temp directory to ${temp_directory}":
+      path    => '/etc/cassandra/conf/jvm.options',
+      line    => "-Djava.io.tmpdir=${temp_directory}",
+      require => File[$temp_directory],
+    }
   }
 }

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -76,7 +76,7 @@ class cassandra::java (
     file_line { "Setting java temp directory to ${temp_directory}":
       path    => '/etc/cassandra/conf/jvm.options',
       line    => "-Djava.io.tmpdir=${temp_directory}",
-      require => File[$temp_directory], Package[$package_name]
+      require => Package[$package_name]
     }
   }
 }

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -76,7 +76,7 @@ class cassandra::java (
     file_line { "Setting java temp directory to ${temp_directory}":
       path    => '/etc/cassandra/conf/jvm.options',
       line    => "-Djava.io.tmpdir=${temp_directory}",
-      require => File[$temp_directory],
+      require => File[$temp_directory], Package[$package_name]
     }
   }
 }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -147,6 +147,18 @@ describe 'cassandra::java' do
     end
   end
 
+  context 'Ensure that temp_directory can be specified.' do
+    let :paraams do
+      {
+        temp_directory: '/tmp/java-tibers-temp',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('/tmp/java-tibers-temp')
+    end
+  end
+
   context 'Ensure that Apt key and source can be specified.' do
     let :facts do
       {

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -155,11 +155,8 @@ describe 'cassandra::java' do
     end
 
     it do
-      is_expected.to contain_file_line("Ensure jvm.options contains the correct line")
-          .with({
-            "path" => "/etc/cassandra/conf/jvm.options",
-            "line" => "-Djava.io.tmpdir=/tmp/java-tibers-temp",
-            })
+      is_expected.to contain_file_line('/etc/cassandra/conf/jvm.options')
+          .with_content('-Djava.io.tmpdir=/tmp/java-tibers-temp')
     end
   end
 

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -154,12 +154,13 @@ describe 'cassandra::java' do
       }
     end
 
-  it do
-    is_expected.to contain_file_line("Ensure jvm.options contains the correct line")
-        .with({
-          "path" => "/etc/cassandra/conf/jvm.options",
-          "line" => "-Djava.io.tmpdir=/tmp/java-tibers-temp",
-          })
+    it do
+      is_expected.to contain_file_line("Ensure jvm.options contains the correct line")
+          .with({
+            "path" => "/etc/cassandra/conf/jvm.options",
+            "line" => "-Djava.io.tmpdir=/tmp/java-tibers-temp",
+            })
+    end
   end
 
   context 'Ensure that Apt key and source can be specified.' do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -148,7 +148,7 @@ describe 'cassandra::java' do
   end
 
   context 'Ensure that temp_directory can be specified.' do
-    let :paraams do
+    let :params do
       {
         temp_directory: '/tmp/java-tibers-temp',
       }

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -147,16 +147,19 @@ describe 'cassandra::java' do
     end
   end
 
-  context 'Ensure that temp_directory can be specified.' do
+  context 'Ensure temp_directory can be set' do
     let :params do
       {
         temp_directory: '/tmp/java-tibers-temp',
       }
     end
 
-    it do
-      is_expected.to contain_file('/tmp/java-tibers-temp')
-    end
+  it do
+    is_expected.to contain_file_line("Ensure jvm.options contains the correct line")
+        .with({
+          "path" => "/etc/cassandra/conf/jvm.options",
+          "line" => "-Djava.io.tmpdir=/tmp/java-tibers-temp",
+          })
   end
 
   context 'Ensure that Apt key and source can be specified.' do

--- a/spec/classes/java_spec.rb
+++ b/spec/classes/java_spec.rb
@@ -150,13 +150,13 @@ describe 'cassandra::java' do
   context 'Ensure temp_directory can be set' do
     let :params do
       {
-        temp_directory: '/tmp/java-tibers-temp',
+        temp_directory: '/tmp/java-tibers-temp'
       }
     end
 
     it do
       is_expected.to contain_file_line('/etc/cassandra/conf/jvm.options')
-          .with_content('-Djava.io.tmpdir=/tmp/java-tibers-temp')
+        .with_content('-Djava.io.tmpdir=/tmp/java-tibers-temp')
     end
   end
 


### PR DESCRIPTION
So funny story - I was chasing what I thought was a problem with centOS 7's jna when working in our private cloud where the guys swore up and down they didn't twiddle anything in the baked images they gave us. But, this all worked fine in AWS, so I knew something had been hardened, but didn't know what. 

This manifests itself in the logs as:
```ERROR 17:49:12 Error in ThreadPoolExecutor
java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.Native
        at org.apache.cassandra.utils.memory.MemoryUtil.allocate(MemoryUtil.java:97) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.util.Memory.<init>(Memory.java:74) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.util.Memory.allocate(Memory.java:97) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.IndexSummary$IndexSummarySerializer.deserialize(IndexSummary.java:328) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader.loadSummary(SSTableReader.java:854) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader.load(SSTableReader.java:734) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader.load(SSTableReader.java:706) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader.open(SSTableReader.java:492) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader.open(SSTableReader.java:375) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at org.apache.cassandra.io.sstable.format.SSTableReader$4.run(SSTableReader.java:534) ~[apache-cassandra-3.0.8.jar:3.0.8]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[na:1.8.0_101]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[na:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [na:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [na:1.8.0_101]
        at java.lang.Thread.run(Unknown Source) [na:1.8.0_101]```

There's not a lot of hints about this error except for:
https://upsource-support.jetbrains.com/hc/en-us/articles/208727169-Error-Could-not-initialize-class-com-sun-jna-Native-
https://docs.datastax.com/en/datastax_enterprise/4.8/datastax_enterprise/sec/secMakingTmpNonexecutable.html

Since we can't change the permissions on /tmp for compliance reasons, I wrote this workaround.

Also I wrote rspec because I always feel bad making you do the rspec, but I probably mangled it pretty good.