### PR TITLE
Corrected tags.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,7 @@
     "database",
     "datastax",
     "datastax-agent",
-    "nosql",
-    "opscenter"
+    "nosql"
   ],
   "requirements": [
     {


### PR DESCRIPTION
There was still a tag for OpsCenter but all functions for that were divested to `locp-opscenter' in version 2.0.0 of this module.