### PR TITLE
Reintroduce Attributes (#300) (#304)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,30 +16,6 @@ dependencies:
   post:
     - rvm cleanup all
 deployment: 
-  bugfix: 
-    branch: /^bugfix.*/
-    commands: 
-      - "./scripts/circle.bash merge release/patch"
-  enhancement_v210:
-    branch: enhancement/v2.1.0
-    commands:
-      - "./scripts/circle.bash merge release/minor"
-  improvement: 
-    branch: /^improvement.*/
-    commands: 
-      - "./scripts/circle.bash merge release/patch"
-  legacy_bugfix:
-    branch: /^legacy/bugfix.*/
-    commands: 
-      - "./scripts/circle.bash merge legacy/patch"
-  legacy_improvement:
-    branch: /^legacy/improvement.*/
-    commands: 
-      - "./scripts/circle.bash merge legacy/patch"
-  legacy_patch_release:
-    branch: legacy/patch
-    commands: 
-      - "./scripts/circle.bash merge legacy/minor"
   master: 
     branch: master
     commands: 
@@ -48,14 +24,6 @@ deployment:
       - git config --global user.name "CircleCI"
       - bundle exec rake strings:gh_pages:update
       - ./scripts/circle.bash deploy
-  patch_release: 
-    branch: release/patch
-    commands: 
-      - "./scripts/circle.bash merge release/minor"
-  remove_config_path_parents:
-    branch: spike/remove_config_path_parents
-    commands:
-      - "./scripts/circle.bash merge release/major"
 machine: 
   environment:
     BEAKER_GEM_VERSION: '<= 2.33.0'

--- a/examples/getting_started.pp
+++ b/examples/getting_started.pp
@@ -16,19 +16,19 @@ include cassandra::java
 # the node itself becomes a seed for the cluster.
 
 class { 'cassandra':
-  package_name   => 'cassandra30',
-  settings       => {
+  commitlog_directory    => '/var/lib/cassandra/commitlog',
+  data_file_directories  => ['/var/lib/cassandra/data'],
+  hints_directory        => '/var/lib/cassandra/hints',
+  package_name           => 'cassandra30',
+  saved_caches_directory => '/var/lib/cassandra/saved_caches',
+  settings               => {
     'authenticator'               => 'PasswordAuthenticator',
     'cluster_name'                => 'MyCassandraCluster',
-    'commitlog_directory'         => '/var/lib/cassandra/commitlog',
     'commitlog_sync'              => 'periodic',
     'commitlog_sync_period_in_ms' => 10000,
-    'data_file_directories'       => ['/var/lib/cassandra/data'],
     'endpoint_snitch'             => 'GossipingPropertyFileSnitch',
-    'hints_directory'             => '/var/lib/cassandra/hints',
     'listen_address'              => $::ipaddress,
     'partitioner'                 => 'org.apache.cassandra.dht.Murmur3Partitioner',
-    'saved_caches_directory'      => '/var/lib/cassandra/saved_caches',
     'seed_provider'               => [
       {
         'class_name' => 'org.apache.cassandra.locator.SimpleSeedProvider',
@@ -41,8 +41,8 @@ class { 'cassandra':
     ],
     'start_native_transport'      => true,
   },
-  service_ensure => running,
-  require        => Class['cassandra::datastax_repo', 'cassandra::java'],
+  service_ensure         => running,
+  require                => Class['cassandra::datastax_repo', 'cassandra::java'],
 }
 
 class { 'cassandra::datastax_agent':
@@ -148,9 +148,10 @@ cassandra::file { "Set Java/Cassandra heap new size to ${heap_new_size}.":
 $tmpdir = '/var/lib/cassandra/tmp'
 
 file { $tmpdir:
-  ensure => directory,
-  owner  => 'cassandra',
-  group  => 'cassandra',
+  ensure  => directory,
+  owner   => 'cassandra',
+  group   => 'cassandra',
+  require => Package['cassandra'],
 }
 
 cassandra::file { 'Set java.io.tmpdir':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,62 +1,91 @@
 # A class for installing the Cassandra package and manipulate settings in the
 # configuration file.
 #
-# @param cassandra_2356_sleep_seconds
+# @param cassandra_2356_sleep_seconds [boolean]
 #   This will provide a workaround for
 #   [CASSANDRA-2356](https://issues.apache.org/jira/browse/CASSANDRA-2356) by
 #   sleeping for the specifed number of seconds after an event involving the
 #   Cassandra package.  This option is silently ignored on the Red Hat family
 #   of operating systems as this bug only affects Debian systems.
-# @param cassandra_9822 If set to true, this will apply a patch to the init
+# @param cassandra_9822 [boolean] If set to true, this will apply a patch to the init
 #   file for the Cassandra service as a workaround for
 #   [CASSANDRA-9822](https://issues.apache.org/jira/browse/CASSANDRA-9822).
 #   This this bug only affects Debian systems.
-# @param cassandra_yaml_tmpl The path to the Puppet template for the
+# @param cassandra_yaml_tmpl [string] The path to the Puppet template for the
 #   Cassandra configuration file.  This allows the user to supply their own
 #   customized template.`
-# @param config_file_mode The permissions mode of the cassandra configuration
+# @param commitlog_directory [string] The path to the commitlog directory.
+#   If set, the directory will be managed as a Puppet resource.  Do not
+#   specify a value here and in the `settings` hash as they are mutually
+#   exclusive.
+# @param commitlog_directory_mode [string]  The mode for the
+#   `commitlog_directory` is ignored unless `commitlog_directory` is
+#   specified.
+# @param config_file_mode [string] The permissions mode of the cassandra configuration
 #   file.
-# @param config_path The path to the cassandra configuration file.
-# @param dc Sets the value for dc in *config_path*/*snitch_properties_file*
+# @param config_path [string] The path to the cassandra configuration file.
+# @param data_file_directories [array] The path(s) to the date directory or
+#   directories.
+#   If set, the directories will be managed as a Puppet resource.  Do not
+#   specify a value here and in the `settings` hash as they are mutually
+#   exclusive.
+# @param data_file_directories_mode [string]  The mode for the
+#   `data_file_directories` is ignored unless `data_file_directories` is
+#   specified.
+# @param dc [string] Sets the value for dc in *config_path*/*snitch_properties_file*
 #   http://docs.datastax.com/en/cassandra/2.1/cassandra/architecture/architectureSnitchesAbout_c.html
 #   for more details.
-# @param dc_suffix Sets the value for dc_suffix in
+# @param dc_suffix [string] Sets the value for dc_suffix in
 #   *config_path*/*snitch_properties_file* see
 #   http://docs.datastax.com/en/cassandra/2.1/cassandra/architecture/architectureSnitchesAbout_c.html
 #   for more details.  If the value is *undef* then no change will be made to
 #   the snitch properties file for this setting.
-# @param fail_on_non_supported_os A flag that dictates if the module should
+# @param fail_on_non_supported_os [boolean] A flag that dictates if the module should
 #   fail if it is not RedHat or Debian.  If you set this option to false then
 #   you must also at least set the `config_path` attribute as well.
-# @param package_ensure The status of the package specified in
+# @param hints_directory [string] The path to the hints directory.
+#   If set, the directory will be managed as a Puppet resource.  Do not
+#   specify a value here and in the `settings` hash as they are mutually
+#   exclusive.  Do not set this option in Cassandra versions before 3.0.0.
+# @param hints_directory_mode [string]  The mode for the
+#   `hints_directory` is ignored unless `hints_directory` is
+#   specified.
+# @param package_ensure [present|latest|string] The status of the package specified in
 #   **package_name**.  Can be *present*, *latest* or a specific version
 #   number.
-# @param package_name The name of the Cassandra package which must be available
+# @param package_name [string] The name of the Cassandra package which must be available
 #   from a repository.
-# @param prefer_local Sets the value for prefer_local in
+# @param prefer_local [boolean] Sets the value for prefer_local in
 #   *config_path*/*snitch_properties_file* see
 #   http://docs.datastax.com/en/cassandra/2.1/cassandra/architecture/architectureSnitchesAbout_c.html
 #   for more details.  Valid values are true, false or *undef*.  If the value
 #   is *undef* then change will be made to the snitch properties file for
 #   this setting.
-# @param rack Sets the value for rack in
+# @param rack [string] Sets the value for rack in
 #   *config_path*/*snitch_properties_file* see
 #   http://docs.datastax.com/en/cassandra/2.1/cassandra/architecture/architectureSnitchesAbout_c.html
 #   for more details.
-# @param rackdc_tmpl The template for creating the snitch properties file.
-# @param service_enable enable the Cassandra service to start at boot time.
-# @param service_ensure Ensure the Cassandra service is running.  Valid values
+# @param rackdc_tmpl [string] The template for creating the snitch properties file.
+# @param saved_caches_directory [string] The path to the saved caches directory.
+#   If set, the directory will be managed as a Puppet resource.  Do not
+#   specify a value here and in the `settings` hash as they are mutually
+#   exclusive.
+# @param saved_caches_directory_mode [string]  The mode for the
+#   `saved_caches_directory` is ignored unless `saved_caches_directory` is
+#   specified.
+# @param service_enable [boolean] enable the Cassandra service to start at boot time.
+# @param service_ensure [string] Ensure the Cassandra service is running.  Valid values
 #   are running or stopped.
-# @param service_name The name of the service that runs the Cassandra software.
-# @param service_provider The name of the provider that runs the service.
+# @param service_name [string] The name of the service that runs the Cassandra software.
+# @param service_provider [string] The name of the provider that runs the service.
 #   If left as *undef* then the OS family specific default will
 #   be used, otherwise the specified value will be used instead.
-# @param service_refresh If set to true, changes to the Cassandra config file
+# @param service_refresh [boolean] If set to true, changes to the Cassandra config file
 #   or the data directories will ensure that Cassandra service is refreshed
 #   after the changes.  Setting this flag to false will disable this
 #   behaviour, therefore allowing the changes to be made but allow the user
 #   to control when the service is restarted.
-# @param settings A hash that is passed to `to_yaml` which dumps the results
+# @param settings [hash] A hash that is passed to `to_yaml` which dumps the results
 #   to the Cassandra configuring file.  The minimum required settings for
 #   Cassandra 2.X are as follows:
 #
@@ -87,7 +116,7 @@
 #   ```
 #   For Cassandra 3.X you will also need to specify the `hints_directory`
 #   attribute.
-# @param snitch_properties_file The name of the snitch properties file.  The
+# @param snitch_properties_file [string] The name of the snitch properties file.  The
 #   full path name would be *config_path*/*snitch_properties_file*.
 # @param systemctl [string] The full path to the systemctl command.  Only
 #   needed when the package is installed.  Will silently continue if the
@@ -96,16 +125,24 @@ class cassandra (
   $cassandra_2356_sleep_seconds = 5,
   $cassandra_9822               = false,
   $cassandra_yaml_tmpl          = 'cassandra/cassandra.yaml.erb',
+  $commitlog_directory          = undef,
+  $commitlog_directory_mode     = '0750',
   $config_file_mode             = '0644',
   $config_path                  = $::cassandra::params::config_path,
+  $data_file_directories        = undef,
+  $data_file_directories_mode   = '0750',
   $dc                           = 'DC1',
   $dc_suffix                    = undef,
   $fail_on_non_supported_os     = true,
+  $hints_directory              = undef,
+  $hints_directory_mode         = '0750',
   $package_ensure               = 'present',
   $package_name                 = $::cassandra::params::cassandra_pkg,
   $prefer_local                 = undef,
   $rack                         = 'RAC1',
   $rackdc_tmpl                  = 'cassandra/cassandra-rackdc.properties.erb',
+  $saved_caches_directory       = undef,
+  $saved_caches_directory_mode  = '0750',
   $service_enable               = true,
   $service_ensure               = undef,
   $service_name                 = 'cassandra',
@@ -218,6 +255,77 @@ class cassandra (
     mode    => '0755',
     require => $config_path_require,
   }
+
+  if $commitlog_directory {
+    file { $commitlog_directory:
+      ensure  => directory,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      mode    => $commitlog_directory_mode,
+      require => $data_dir_require,
+      before  => $data_dir_before,
+    }
+
+    $commitlog_directory_settings = merge($settings,
+      { 'commitlog_directory' => $commitlog_directory })
+  } else {
+    $commitlog_directory_settings = $settings
+  }
+
+  if is_array($data_file_directories) {
+    file { $data_file_directories:
+      ensure  => directory,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      mode    => $data_file_directories_mode,
+      require => $data_dir_require,
+      before  => $data_dir_before,
+    }
+
+    $data_file_directories_settings = merge($settings, {
+      'data_file_directories' => $data_file_directories,
+    })
+  } else {
+    $data_file_directories_settings = $settings
+  }
+
+  if $hints_directory {
+    file { $hints_directory:
+      ensure  => directory,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      mode    => $hints_directory_mode,
+      require => $data_dir_require,
+      before  => $data_dir_before,
+    }
+
+    $hints_directory_settings = merge($settings,
+      { 'hints_directory' => $hints_directory })
+  } else {
+    $hints_directory_settings = $settings
+  }
+
+  if $saved_caches_directory {
+    file { $saved_caches_directory:
+      ensure  => directory,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      mode    => $saved_caches_directory_mode,
+      require => $data_dir_require,
+      before  => $data_dir_before,
+    }
+
+    $saved_caches_directory_settings = merge($settings,
+      { 'saved_caches_directory' => $saved_caches_directory})
+  } else {
+    $saved_caches_directory_settings = $settings
+  }
+
+  $merged_settings = merge($settings,
+    $commitlog_directory_settings,
+    $data_file_directories_settings,
+    $hints_directory_settings,
+    $saved_caches_directory_settings)
 
   file { $config_file:
     ensure  => present,

--- a/spec/classes/datastax_agent_spec.rb
+++ b/spec/classes/datastax_agent_spec.rb
@@ -13,13 +13,6 @@ describe 'cassandra::datastax_agent' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('validate_hash', type: :statement) do |_f|
-    end
-    MockFunction.new('create_ini_settings', type: :statement) do |_f|
-    end
-  end
-
   context 'Test for cassandra::datastax_agent with defaults (RedHat).' do
     let :facts do
       {

--- a/spec/classes/firewall_ports_spec.rb
+++ b/spec/classes/firewall_ports_spec.rb
@@ -7,23 +7,6 @@ describe 'cassandra::firewall_ports' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('prefix') do |f|
-      f.stubbed.with(['0.0.0.0/0'],
-                     '200_Public_').returns('200_Public_0.0.0.0/0')
-      f.stubbed.with(['0.0.0.0/0'],
-                     '210_InterNode_').returns('210_InterNode__0.0.0.0/0')
-      f.stubbed.with(['0.0.0.0/0'],
-                     '220_Client_').returns('220_Client__0.0.0.0/0')
-    end
-    MockFunction.new('concat') do |f|
-      f.stubbed.returns([8888, 22])
-    end
-    MockFunction.new('size') do |f|
-      f.stubbed.returns(42)
-    end
-  end
-
   context 'Run with defaults.' do
     it do
       should have_resource_count(2)

--- a/spec/classes/schema_spec.rb
+++ b/spec/classes/schema_spec.rb
@@ -11,21 +11,6 @@ describe 'cassandra::schema' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('strftime') do |f|
-      f.stubbed.with('/var/lib/cassandra-%F')
-       .returns('/var/lib/cassandra-YYYY-MM-DD')
-    end
-  end
-
   context 'Ensure that a connection test is made.' do
     let :facts do
       {

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -14,21 +14,6 @@ describe '::cassandra::file' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('strftime') do |f|
-      f.stubbed.with('/var/lib/cassandra-%F')
-       .returns('/var/lib/cassandra-YYYY-MM-DD')
-    end
-  end
-
   context 'On a Debian OS set the max and new heap size' do
     let :facts do
       {

--- a/spec/defines/private/deprecation_warning_spec.rb
+++ b/spec/defines/private/deprecation_warning_spec.rb
@@ -14,21 +14,6 @@ describe '::cassandra::private::deprecation_warning' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('strftime') do |f|
-      f.stubbed.with('/var/lib/cassandra-%F')
-       .returns('/var/lib/cassandra-YYYY-MM-DD')
-    end
-  end
-
   context 'Test ::cassandra::private::deprecation_warning' do
     let :facts do
       {

--- a/spec/defines/private/firewall_ports/rule_spec.rb
+++ b/spec/defines/private/firewall_ports/rule_spec.rb
@@ -4,19 +4,6 @@ describe 'cassandra::private::firewall_ports::rule' do
     ['define firewall ($action, $dport, $proto, $source) {}']
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('prefix') do |f|
-      f.stubbed.with(['0.0.0.0/0'],
-                     '200_Public_').returns('200_Public_0.0.0.0/0')
-      f.stubbed.with(['0.0.0.0/0'],
-                     '210_InterNode_').returns('210_InterNode__0.0.0.0/0')
-      f.stubbed.with(['0.0.0.0/0'],
-                     '220_Client_').returns('220_Client__0.0.0.0/0')
-    end
-    MockFunction.new('concat') { |f| f.stubbed.returns([8888, 22]) }
-    MockFunction.new('size') { |f| f.stubbed.returns(42) }
-  end
-
   context 'Test that rules can be set.' do
     let(:title) { '200_Public_0.0.0.0/0' }
     let :params do

--- a/spec/defines/schema/cql_type_spec.rb
+++ b/spec/defines/schema/cql_type_spec.rb
@@ -12,25 +12,6 @@ describe 'cassandra::schema::cql_type' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('join') do |f|
-      f.stubbed.with(['firstname text', 'lastname text'], ', ')
-       .returns('firstname text, lastname text')
-    end
-    MockFunction.new('join_keys_to_values') do |f|
-      f.stubbed.with({ 'firstname' => 'text', 'lastname' => 'text' }, ' ')
-       .returns(['firstname text', 'lastname text'])
-    end
-  end
-
   context 'CQL TYPE (fullname)' do
     let :facts do
       {

--- a/spec/defines/schema/index_spec.rb
+++ b/spec/defines/schema/index_spec.rb
@@ -12,17 +12,6 @@ describe 'cassandra::schema::index' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-  end
-
   context 'Create a basic index' do
     let :facts do
       {

--- a/spec/defines/schema/keyspace_spec.rb
+++ b/spec/defines/schema/keyspace_spec.rb
@@ -12,53 +12,6 @@ describe 'cassandra::schema::keyspace' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('delete') do |f|
-      f.stubbed.with(
-        {
-          'keyspace_class' => 'NetworkTopologyStrategy',
-          'dc1' => '3',
-          'dc2' => '2'
-        },
-        'keyspace_class'
-      ).returns('dc1' => '3', 'dc2' => '2')
-    end
-    MockFunction.new('join') do |f|
-      f.stubbed.with(
-        {
-          '\'dc1\': ' => '3',
-          '\'dc2\': ' => '2'
-        },
-        ', '
-      ).returns('\'dc1\': 3, \'dc2\': 2')
-    end
-    MockFunction.new('join_keys_to_values') do |f|
-      f.stubbed.with(
-        {
-          '\'dc1' => '3',
-          '\'dc2' => '2'
-        },
-        '\': '
-      ).returns('\'dc1\': ' => '3', '\'dc2\': ' => '2')
-    end
-    MockFunction.new('prefix') do |f|
-      f.stubbed.with(
-        {
-          'dc1' => '3',
-          'dc2' => '2'
-        }, '\''
-      ).returns('\'dc1' => '3', '\'dc2' => '2')
-    end
-  end
-
   context 'Set ensure to present (SimpleStrategy)' do
     let :facts do
       {

--- a/spec/defines/schema/table_spec.rb
+++ b/spec/defines/schema/table_spec.rb
@@ -12,59 +12,6 @@ describe 'cassandra::schema::table' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-    MockFunction.new('count') do |f|
-      f.stubbed.with(
-        [
-          'COMPACT STORAGE',
-          'ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\''
-        ]
-      ).returns(2)
-    end
-    MockFunction.new('delete') do |f|
-      f.stubbed.with('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, COLLECTION-TYPE tuple<int, text,text>, PRIMARY KEY (userid)', 'COLLECTION-TYPE ').returns('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, tuple<int, text,text>, PRIMARY KEY (userid)')
-    end
-    MockFunction.new('join') do |f|
-      f.stubbed.with(
-        [
-          'COMPACT STORAGE', 'ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\''
-        ], ' AND '
-      ).returns("COMPACT STORAGE AND ID='5a1c395e-b41f-11e5-9f22-ba0be0483c18'")
-      f.stubbed.with(
-        [
-          'userid text', 'username FROZEN<fullname>', 'emails set<text>',
-          'top_scores list<int>', 'todo map<timestamp, text>',
-          'COLLECTION-TYPE tuple<int, text,text>', 'PRIMARY KEY (userid)'
-        ], ', '
-      ).returns('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, COLLECTION-TYPE tuple<int, text,text>, PRIMARY KEY (userid)')
-    end
-    MockFunction.new('join_keys_to_values') do |f|
-      f.stubbed.with(
-        {
-          'userid' => 'text', 'username' => 'FROZEN<fullname>',
-          'emails' => 'set<text>', 'top_scores' => 'list<int>',
-          'todo' => 'map<timestamp, text>',
-          'COLLECTION-TYPE' => 'tuple<int, text,text>',
-          'PRIMARY KEY' => '(userid)'
-        }, ' '
-      ).returns(
-        [
-          'userid text', 'username FROZEN<fullname>', 'emails set<text>',
-          'top_scores list<int>', 'todo map<timestamp, text>',
-          'COLLECTION-TYPE tuple<int, text,text>', 'PRIMARY KEY (userid)'
-        ]
-      )
-    end
-  end
-
   context 'Create Table' do
     let :facts do
       {

--- a/spec/defines/schema/user_spec.rb
+++ b/spec/defines/schema/user_spec.rb
@@ -12,17 +12,6 @@ describe 'cassandra::schema::user' do
     ]
   end
 
-  let!(:stdlib_stubs) do
-    MockFunction.new('concat') do |f|
-      f.stubbed.with([], '/etc/cassandra')
-       .returns(['/etc/cassandra'])
-      f.stubbed.with([], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra/default.conf'])
-      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
-       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
-    end
-  end
-
   context 'Create a user' do
     let :facts do
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,128 @@ RSpec.configure do |config|
   config.tty = true
   config.mock_with :rspec
   config.raise_errors_for_deprecations!
+
+  config.before(:each) do
+    MockFunction.new('concat') do |f|
+      f.stubbed.returns([8888, 22])
+      f.stubbed.with([], '/etc/cassandra')
+       .returns(['/etc/cassandra'])
+      f.stubbed.with([], '/etc/cassandra/default.conf')
+       .returns(['/etc/cassandra/default.conf'])
+      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
+       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
+    end
+
+    MockFunction.new('count') do |f|
+      f.stubbed.with(
+        [
+          'COMPACT STORAGE',
+          'ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\''
+        ]
+      ).returns(2)
+    end
+
+    MockFunction.new('create_ini_settings', type: :statement) do |f|
+    end
+
+    MockFunction.new('delete') do |f|
+      f.stubbed.with(
+        {
+          'keyspace_class' => 'NetworkTopologyStrategy',
+          'dc1' => '3',
+          'dc2' => '2'
+        },
+        'keyspace_class'
+      ).returns('dc1' => '3', 'dc2' => '2')
+      f.stubbed.with('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, COLLECTION-TYPE tuple<int, text,text>, PRIMARY KEY (userid)', 'COLLECTION-TYPE ').returns('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, tuple<int, text,text>, PRIMARY KEY (userid)')
+    end
+
+    MockFunction.new('is_array') do |f|
+      f.stubbed.with('').returns(false)
+      f.stubbed.with(['/var/lib/cassandra/data']).returns(true)
+    end
+
+    MockFunction.new('join') do |f|
+      f.stubbed.with(['firstname text', 'lastname text'], ', ')
+       .returns('firstname text, lastname text')
+      f.stubbed.with(
+        {
+          '\'dc1\': ' => '3',
+          '\'dc2\': ' => '2'
+        },
+        ', '
+      ).returns('\'dc1\': 3, \'dc2\': 2')
+      f.stubbed.with(
+        [
+          'COMPACT STORAGE', 'ID=\'5a1c395e-b41f-11e5-9f22-ba0be0483c18\''
+        ], ' AND '
+      ).returns("COMPACT STORAGE AND ID='5a1c395e-b41f-11e5-9f22-ba0be0483c18'")
+      f.stubbed.with(
+        [
+          'userid text', 'username FROZEN<fullname>', 'emails set<text>',
+          'top_scores list<int>', 'todo map<timestamp, text>',
+          'COLLECTION-TYPE tuple<int, text,text>', 'PRIMARY KEY (userid)'
+        ], ', '
+      ).returns('userid text, username FROZEN<fullname>, emails set<text>, top_scores list<int>, todo map<timestamp, text>, COLLECTION-TYPE tuple<int, text,text>, PRIMARY KEY (userid)')
+    end
+
+    MockFunction.new('join_keys_to_values') do |f|
+      f.stubbed.with({ 'firstname' => 'text', 'lastname' => 'text' }, ' ')
+       .returns(['firstname text', 'lastname text'])
+      f.stubbed.with(
+        {
+          '\'dc1' => '3',
+          '\'dc2' => '2'
+        },
+        '\': '
+      ).returns('\'dc1\': ' => '3', '\'dc2\': ' => '2')
+      f.stubbed.with(
+        {
+          'userid' => 'text', 'username' => 'FROZEN<fullname>',
+          'emails' => 'set<text>', 'top_scores' => 'list<int>',
+          'todo' => 'map<timestamp, text>',
+          'COLLECTION-TYPE' => 'tuple<int, text,text>',
+          'PRIMARY KEY' => '(userid)'
+        }, ' '
+      ).returns(
+        [
+          'userid text', 'username FROZEN<fullname>', 'emails set<text>',
+          'top_scores list<int>', 'todo map<timestamp, text>',
+          'COLLECTION-TYPE tuple<int, text,text>', 'PRIMARY KEY (userid)'
+        ]
+      )
+    end
+
+    MockFunction.new('merge') do |f|
+    end
+
+    MockFunction.new('prefix') do |f|
+      f.stubbed.with(['0.0.0.0/0'],
+                     '200_Public_').returns('200_Public_0.0.0.0/0')
+      f.stubbed.with(['0.0.0.0/0'],
+                     '210_InterNode_').returns('210_InterNode__0.0.0.0/0')
+      f.stubbed.with(['0.0.0.0/0'],
+                     '220_Client_').returns('220_Client__0.0.0.0/0')
+      f.stubbed.with(
+        {
+          'dc1' => '3',
+          'dc2' => '2'
+        }, '\''
+      ).returns('\'dc1' => '3', '\'dc2' => '2')
+    end
+
+    MockFunction.new('size') do |f|
+      f.stubbed.returns(42)
+    end
+
+    MockFunction.new('strftime') do |f|
+      f.stubbed.with('/var/lib/cassandra-%F')
+       .returns('/var/lib/cassandra-YYYY-MM-DD')
+    end
+
+    MockFunction.new('validate_hash', type: :statement) do |f|
+    end
+  end
 end
 
 Coveralls.wear!

--- a/templates/cassandra.yaml.erb
+++ b/templates/cassandra.yaml.erb
@@ -2,4 +2,4 @@
 # overwritten.  If you see that the YAML indentation looks somewhat strange,
 # don't worry, please see the following ticker for more details.
 # https://tickets.puppetlabs.com/browse/PUP-3120
-<%= @settings.to_yaml() %>
+<%= @merged_settings.to_yaml() %>


### PR DESCRIPTION
* Making a start on #294.

* Markdown corrections (#294).

* Add facts to the module.

* More work on facts.

* Added yard.

* Get some order into the .gitignore.

* Added .yardoc/

* puppet-strings documentation.

* Documentation WIP.

* Gem/Rake fixing.

* Added puppet-strings and yard.

* Added YARD options and bundle exec rake strings:generate to Circle build.

* Added puppet-strings/tasks to tasks.

* Make the Gemfile more generic.

* Remove beaker/acceptance tests from TravisCI.

* Appease RuboCop.

* Bumped the version of Ruby.

* Updated spec tests and new systemctl attribute.

* Typo

* Added strings:gh_pages:update.

* WIP

* Configure Git on CircleCI.

* Typo.

* Added puppet-strings to manifests/schema/table.pp.

* Don't build on gh-pages branch and only generate documentation when deploying from master.

* Disable Style/FrozenStringLiteralComment.

* Revert TravisCI node matrix.

* More work on CircleCI configuration.

* Set tins gem to 0.8.4 for 1.9.3.

* NET_SSH_GEM_VERSION=2.9.4.

* Cache bundler stuff.

* NET_HTTP_PERSISTENT_GEM_VERSION=2.9.4

* WIP

* Corrected Gem name.

* WIP

* Fix TravisCI build failures.

* More generic Gemfile refactoring.

* Ruby refactoring.

* Testing.

* Remove cludge for datastax-agent.

* enhancement_v210

* Added beaker-puppet_install_helper and removed serverspec.

* Set the beaker version to 2.33.0.

* Corrected the mode for the datastax-agent configuration file.

* Add links to puppet-strings documentation.

* Changed mode of datastax_agent from 0640 to 0644.

* Set the beaker gem version.

* Appease Rubocop.

* Deployment for #300.

* Corrected deployment target #300.

* WIP

* Centralized the mock functions into spec/spec_helper.rb (#300).

* Appease rspec and Ruby 1.9.3 (#300).

* Added doc strings for new attributes (#300).