### PR TITLE
Correct cql_types conditional in cassandra::schema class

### DIFF
--- a/manifests/schema.pp
+++ b/manifests/schema.pp
@@ -89,7 +89,7 @@ class cassandra::schema (
   }
 
   # manage cql_types if present
-  if $keyspaces {
+  if $cql_types {
     create_resources('cassandra::schema::cql_type', $cql_types)
   }
 


### PR DESCRIPTION
Previously if only cql_types parameter is passed to the schema class, the class will not create the resources as the if statement checks for if keyspaces are present, not cql_types. This changes the behavior to verify that cql_types is passed before creating the resources instead. 