### PR TITLE
make cluster_name available outside of the settings hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,29 @@ class { 'cassandra':
 }
 ```
 
+### Quickstart with Hiera
+If you're using Hiera, there's a powerful pattern for standing up boxes and clusters quickly and easily when using this module. In your top level node classification (usually common.yaml), add the settings hash and all the tweaks you want all the clusters to use:
+```
+cassandra::settings:
+  authenticator: AllowAllAuthenticator
+  authorizer: AllowAllAuthorizer
+  auto_bootstrap: true
+  auto_snapshot: true
+  ...
+```
+Then, in the individual node classification (something like myhost.yaml for myhost01, myhost02, myhost03...), add the parts which define the cluster:
+```
+cassandra::cluster_name: developer playground cassandra cluster
+cassandra::dc: Onsite1
+cassandra::rack: RAC1
+cassandra::package_ensure: 3.0.5-1
+cassandra::package_name: cassandra30
+cassandra::datastax_agent::package_name: dsc30
+cassandra::datastax_agent::package_ensure:  3.0.5-1
+```
+
+**Gotcha:** The *most specific instance* of the settings hash is the one hiera will use, deeper merge will not combine the hashes. Omitting `cassandra::cluster_name` will default to use the one in the settings hash. 
+
 ## Usage
 
 ### Setup a keyspace and users

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,12 +260,8 @@ class cassandra (
   }
   
   if $cluster_name {
-    $cluster_name_settings = merge($settings,
-      { 'cluster_name' => $cluster_name, })
-  } else {
-    $cluster_name_settings = $settings
-  }
-
+    $cluster_name_settings = { 'cluster_name' => $cluster_name, }
+  } 
 
   if $commitlog_directory {
     file { $commitlog_directory:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash(settings,{}),
+  $settings                     = hiera_hash('settings', {}),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash('settings', {}),
+  $settings                     = {},
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = {},
+  $settings                     = hiera_hash('::cassandra::settings', {}),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash('::cassandra::settings'),
+  $settings                     = hiera_hash('::cassandra::settings', {}),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {
@@ -268,7 +268,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $commitlog_directory_settings = merge($settings,
+    $commitlog_directory_settings = deep_merge($settings,
       { 'commitlog_directory' => $commitlog_directory, })
   } else {
     $commitlog_directory_settings = $settings
@@ -284,7 +284,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $data_file_directories_settings = merge($settings, {
+    $data_file_directories_settings = deep_merge($settings, {
       'data_file_directories' => $data_file_directories,
     })
   } else {
@@ -301,7 +301,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $hints_directory_settings = merge($settings,
+    $hints_directory_settings = deep_merge($settings,
       { 'hints_directory' => $hints_directory, })
   } else {
     $hints_directory_settings = $settings
@@ -317,13 +317,13 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $saved_caches_directory_settings = merge($settings,
+    $saved_caches_directory_settings = deep_merge($settings,
       { 'saved_caches_directory' => $saved_caches_directory, })
   } else {
     $saved_caches_directory_settings = $settings
   }
 
-  $merged_settings = merge($settings,
+  $merged_settings = deep_merge($settings,
     $commitlog_directory_settings,
     $data_file_directories_settings,
     $hints_directory_settings,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = {},
+  $settings                     = hiera_hash("::cassandra::settings",{}),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,7 @@ class cassandra (
   $cassandra_2356_sleep_seconds = 5,
   $cassandra_9822               = false,
   $cassandra_yaml_tmpl          = 'cassandra/cassandra.yaml.erb',
+  $cluster_name                 = undef,
   $commitlog_directory          = undef,
   $commitlog_directory_mode     = '0750',
   $config_file_mode             = '0644',
@@ -148,7 +149,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash('::cassandra::settings', {}),
+  $settings                     = {},
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {
@@ -257,6 +258,14 @@ class cassandra (
     mode    => '0755',
     require => $config_path_require,
   }
+  
+  if $cluster_name {
+    $cluster_name_settings = merge($settings,
+      { 'cluster_name' => $cluster_name, })
+  } else {
+    $cluster_name_settings = $settings
+  }
+
 
   if $commitlog_directory {
     file { $commitlog_directory:
@@ -268,7 +277,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $commitlog_directory_settings = deep_merge($settings,
+    $commitlog_directory_settings = merge($settings,
       { 'commitlog_directory' => $commitlog_directory, })
   } else {
     $commitlog_directory_settings = $settings
@@ -284,7 +293,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $data_file_directories_settings = deep_merge($settings, {
+    $data_file_directories_settings = merge($settings, {
       'data_file_directories' => $data_file_directories,
     })
   } else {
@@ -301,7 +310,7 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $hints_directory_settings = deep_merge($settings,
+    $hints_directory_settings = merge($settings,
       { 'hints_directory' => $hints_directory, })
   } else {
     $hints_directory_settings = $settings
@@ -317,13 +326,14 @@ class cassandra (
       before  => $data_dir_before,
     }
 
-    $saved_caches_directory_settings = deep_merge($settings,
+    $saved_caches_directory_settings = merge($settings,
       { 'saved_caches_directory' => $saved_caches_directory, })
   } else {
     $saved_caches_directory_settings = $settings
   }
 
-  $merged_settings = deep_merge($settings,
+  $merged_settings = merge($settings,
+    $cluster_name_settings,
     $commitlog_directory_settings,
     $data_file_directories_settings,
     $hints_directory_settings,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -329,11 +329,11 @@ class cassandra (
   }
 
   $merged_settings = merge($settings,
-    $cluster_name_settings,
     $commitlog_directory_settings,
     $data_file_directories_settings,
     $hints_directory_settings,
-    $saved_caches_directory_settings)
+    $saved_caches_directory_settings,
+    $cluster_name_settings)
 
   file { $config_file:
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,6 +264,8 @@ class cassandra (
 
   if $cluster_name != undef {
     $cluster_name_settings = { 'cluster_name' => $cluster_name, }
+  } else {
+    $cluster_name_settings = $settings
   }
 
   if $commitlog_directory {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,7 +259,7 @@ class cassandra (
     require => $config_path_require,
   }
   
-  if $cluster_name {
+  if $cluster_name != undef {
     $cluster_name_settings = { 'cluster_name' => $cluster_name, }
   } 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,9 @@
 # @param cassandra_yaml_tmpl [string] The path to the Puppet template for the
 #   Cassandra configuration file.  This allows the user to supply their own
 #   customized template.`
+# @param cluster_name [string] The name of the cluster that the node is to
+#   join.  Do not set this variable and also set `cluster_name` in the
+#   `settings` hash.
 # @param commitlog_directory [string] The path to the commitlog directory.
 #   If set, the directory will be managed as a Puppet resource.  Do not
 #   specify a value here and in the `settings` hash as they are mutually

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash('::cassandra::settings', {}),
+  $settings                     = hiera_hash('::cassandra::settings'),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@ class cassandra (
   $service_name                 = 'cassandra',
   $service_provider             = undef,
   $service_refresh              = true,
-  $settings                     = hiera_hash("::cassandra::settings",{}),
+  $settings                     = hiera_hash(settings,{}),
   $snitch_properties_file       = 'cassandra-rackdc.properties',
   $systemctl                    = $::cassandra::params::systemctl,
   ) inherits cassandra::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -258,10 +258,10 @@ class cassandra (
     mode    => '0755',
     require => $config_path_require,
   }
-  
+
   if $cluster_name != undef {
     $cluster_name_settings = { 'cluster_name' => $cluster_name, }
-  } 
+  }
 
   if $commitlog_directory {
     file { $commitlog_directory:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,7 +68,6 @@ describe 'cassandra' do
         cassandra_2356_sleep_seconds: 5,
         cassandra_9822: false,
         cassandra_yaml_tmpl: 'cassandra/cassandra.yaml.erb',
-        cluster_name_settings: nil,
         commitlog_directory_mode: '0750',
         config_file_mode: '0644',
         config_path: '/etc/cassandra/default.conf',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,7 +68,7 @@ describe 'cassandra' do
         cassandra_2356_sleep_seconds: 5,
         cassandra_9822: false,
         cassandra_yaml_tmpl: 'cassandra/cassandra.yaml.erb',
-        cluster_name_settings: nil
+        cluster_name_settings: nil,
         commitlog_directory_mode: '0750',
         config_file_mode: '0644',
         config_path: '/etc/cassandra/default.conf',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,6 +68,7 @@ describe 'cassandra' do
         cassandra_2356_sleep_seconds: 5,
         cassandra_9822: false,
         cassandra_yaml_tmpl: 'cassandra/cassandra.yaml.erb',
+        cluster_name_settings: nil
         commitlog_directory_mode: '0750',
         config_file_mode: '0644',
         config_path: '/etc/cassandra/default.conf',


### PR DESCRIPTION
I played with the settings hash quite a bit trying to make hiera_hash lookup perform a deep merge. Something like have a `dev.yaml` with a bunch of settings in it but have `dlcassandra.yaml` contain the bare minimum elements required to stand up a `dlcassandraXX.mydomain.com` cluster different from `dlanothercassandraXX.mydomain.com` cluster.

I feel this change is in the spirit of the existing work since `dc` and `rack` are already set outside of the hash.

With this I can now have `dlcassandra.yaml` look like:
```
cassandra::cluster_name: dev cassandra test
cassandra::dc: hmskop01
cassandra::rack: RAC1
cassandra::package_ensure: 3.0.5-1
cassandra::package_name: cassandra30
cassandra::datastax_agent::package_name: dsc30
cassandra::datastax_agent::package_ensure:  3.0.5-1
```

Short and sweet, while keeping the settings hash in the `dev.yaml` file.