### PR TITLE
Release 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for Puppet Module locp-cassandra
 
-##2017-02-27 - Release 1.27.0 ([diff](https://github.com/locp/cassandra/compare/1.26.1...1.27.0))
+##2017-02-28 - Release 1.27.0 ([diff](https://github.com/locp/cassandra/compare/1.26.1...1.27.0))
 
 ### Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log for Puppet Module locp-cassandra
 
+##2017-02-27 - Release 1.27.0 ([diff](https://github.com/locp/cassandra/compare/1.26.1...1.27.0))
+
+### Summary
+
+Add the `cassandra::dse` class.
+
 ##2016-11-19 - Release 1.26.1 ([diff](https://github.com/locp/cassandra/compare/1.26.0...1.26.1))
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     * [cassandra](#class-cassandra)
     * [cassandra::datastax_agent](#class-cassandradatastax_agent)
     * [cassandra::datastax_repo](#class-cassandradatastax_repo)
+    * [cassandra::dse](#class-cassandradse)
     * [cassandra::env](#class-cassandraenv)
     * [cassandra::file](#class-cassandrafile)
     * [cassandra::firewall_ports](#class-cassandrafirewall_ports)

--- a/examples/dse.pp
+++ b/examples/dse.pp
@@ -1,0 +1,91 @@
+#############################################################################
+# This is for placing in the getting started section of the README file.
+#############################################################################
+# Install Cassandra 2.2.5 onto a system and create a basic keyspace, table
+# and index.  The node itself becomes a seed for the cluster.
+#
+# Tested on CentOS 7
+#############################################################################
+
+# Cassandra pre-requisites
+include cassandra::datastax_repo
+include cassandra::java
+
+# Create a cluster called MyCassandraCluster which uses the
+# GossipingPropertyFileSnitch.  In this very basic example
+# the node itself becomes a seed for the cluster.
+class { 'cassandra':
+  authenticator   => 'PasswordAuthenticator',
+  cluster_name    => 'MyCassandraCluster',
+  endpoint_snitch => 'GossipingPropertyFileSnitch',
+  listen_address  => $::ipaddress,
+  seeds           => $::ipaddress,
+  service_systemd => true,
+  require         => Class['cassandra::datastax_repo', 'cassandra::java'],
+}
+
+class { 'cassandra::optutils':
+  require => Class['cassandra']
+}
+
+class { 'cassandra::schema':
+  cqlsh_password => 'cassandra',
+  cqlsh_user     => 'cassandra',
+  indexes        => {
+    'users_lname_idx' => {
+      table    => 'users',
+      keys     => 'lname',
+      keyspace => 'mykeyspace',
+    },
+  },
+  keyspaces      => {
+    'mykeyspace' => {
+      durable_writes  => false,
+      replication_map => {
+        keyspace_class     => 'SimpleStrategy',
+        replication_factor => 1,
+      },
+    }
+  },
+  tables         => {
+    'users' => {
+      columns  => {
+        user_id       => 'int',
+        fname         => 'text',
+        lname         => 'text',
+        'PRIMARY KEY' => '(user_id)',
+      },
+      keyspace => 'mykeyspace',
+    },
+  },
+  users          => {
+    'spillman' => {
+      password => 'Niner27',
+    },
+    'akers'    => {
+      password  => 'Niner2',
+      superuser => true,
+    },
+    'boone'    => {
+      password => 'Niner75',
+    },
+    'lucan'    => {
+      'ensure' => absent
+    },
+  },
+}
+
+$heap_new_size = $::processorcount * 100
+
+class { 'cassandra::env':
+  file_lines => {
+    'MAX_HEAP_SIZE' => {
+      line  => 'MAX_HEAP_SIZE="1024M"',
+      match => '#MAX_HEAP_SIZE="4G"',
+    },
+    'HEAP_NEWSIZE'  => {
+      line  => "HEAP_NEWSIZE='${heap_new_size}M'",
+      match => '#HEAP_NEWSIZE="800M"',
+    }
+  }
+}

--- a/examples/getting_started.pp
+++ b/examples/getting_started.pp
@@ -24,37 +24,68 @@ class { 'cassandra':
   require         => Class['cassandra::datastax_repo', 'cassandra::java'],
 }
 
-class { 'cassandra::dse':
-  file_lines => {
-    'Set HADOOP_LOG_DIR directory' => {
-      ensure => present,
-      path   => '/etc/dse/dse-env.sh',
-      line   => 'export HADOOP_LOG_DIR=/var/log/hadoop',
-      match  => '^# export HADOOP_LOG_DIR=<log_dir>',
-    },
-    'Set DSE_HOME'                 => {
-      ensure => present,
-      path   => '/etc/dse/dse-env.sh',
-      line   => 'export DSE_HOME=/usr/share/dse',
-      match  => '^#export DSE_HOME',
+class { 'cassandra::optutils':
+  require => Class['cassandra']
+}
+
+class { 'cassandra::schema':
+  cqlsh_password => 'cassandra',
+  cqlsh_user     => 'cassandra',
+  indexes        => {
+    'users_lname_idx' => {
+      table    => 'users',
+      keys     => 'lname',
+      keyspace => 'mykeyspace',
     },
   },
-  settings   => {
-    ldap_options => {
-      server_host                => localhost,
-      server_port                => 389,
-      search_dn                  => 'cn=Admin',
-      search_password            => secret,
-      use_ssl                    => false,
-      use_tls                    => false,
-      truststore_type            => jks,
-      user_search_base           => 'ou=users,dc=example,dc=com',
-      user_search_filter         => '(uid={0})',
-      credentials_validity_in_ms => 0,
-      connection_pool            => {
-        max_active => 8,
-        max_idle   => 8,
-      }
+  keyspaces      => {
+    'mykeyspace' => {
+      durable_writes  => false,
+      replication_map => {
+        keyspace_class     => 'SimpleStrategy',
+        replication_factor => 1,
+      },
+    }
+  },
+  tables         => {
+    'users' => {
+      columns  => {
+        user_id       => 'int',
+        fname         => 'text',
+        lname         => 'text',
+        'PRIMARY KEY' => '(user_id)',
+      },
+      keyspace => 'mykeyspace',
+    },
+  },
+  users          => {
+    'spillman' => {
+      password => 'Niner27',
+    },
+    'akers'    => {
+      password  => 'Niner2',
+      superuser => true,
+    },
+    'boone'    => {
+      password => 'Niner75',
+    },
+    'lucan'    => {
+      'ensure' => absent
+    },
+  },
+}
+
+$heap_new_size = $::processorcount * 100
+
+class { 'cassandra::env':
+  file_lines => {
+    'MAX_HEAP_SIZE' => {
+      line  => 'MAX_HEAP_SIZE="1024M"',
+      match => '#MAX_HEAP_SIZE="4G"',
+    },
+    'HEAP_NEWSIZE'  => {
+      line  => "HEAP_NEWSIZE='${heap_new_size}M'",
+      match => '#HEAP_NEWSIZE="800M"',
     }
   }
 }

--- a/manifests/dse.pp
+++ b/manifests/dse.pp
@@ -1,0 +1,85 @@
+# A class for configuring DataStax Enterprise (DSE) specific settings.
+#
+# @param config_file [string] The full path to the DSE configuration file.
+# @param config_file_mode [string] The mode for the DSE configuration file.
+# @param dse_yaml_tmpl [string] A path to a template for the `dse.yaml` file.
+# @param file_lines [hash] A hash of values that are passed to
+#   `create_resources` as a `file_line` resource.
+# @param service_refresh [boolean] Whether or not the Cassandra service
+#   should be refreshed if the DSE configuration files are changed.
+# @param settings [hash] Unless this attribute is set to a hash (which is
+#   then placed as YAML inside `dse.yaml`) then the `dse.yaml` is left
+#   unchanged.
+# @example Configure a cluster with LDAP authentication
+#   class { 'cassandra::dse':
+#     file_lines => {
+#       'Set HADOOP_LOG_DIR directory' => {
+#         ensure => present,
+#         path   => '/etc/dse/dse-env.sh',
+#         line   => 'export HADOOP_LOG_DIR=/var/log/hadoop',
+#         match  => '^# export HADOOP_LOG_DIR=<log_dir>',
+#       },
+#       'Set DSE_HOME'                 => {
+#         ensure => present,
+#         path   => '/etc/dse/dse-env.sh',
+#         line   => 'export DSE_HOME=/usr/share/dse',
+#         match  => '^#export DSE_HOME',
+#       },
+#     },
+#     settings   => {
+#       ldap_options => {
+#         server_host                => localhost,
+#         server_port                => 389,
+#         search_dn                  => 'cn=Admin',
+#         search_password            => secret,
+#         use_ssl                    => false,
+#         use_tls                    => false,
+#         truststore_type            => jks,
+#         user_search_base           => 'ou=users,dc=example,dc=com',
+#         user_search_filter         => '(uid={0})',
+#         credentials_validity_in_ms => 0,
+#         connection_pool            => {
+#           max_active => 8,
+#           max_idle   => 8,
+#         }
+#       }
+#     }
+#   }
+class cassandra::dse (
+  $config_file      = '/etc/dse/dse.yaml',
+  $config_file_mode = '0644',
+  $dse_yaml_tmpl    = 'cassandra/dse.yaml.erb',
+  $file_lines       = undef,
+  $service_refresh  = true,
+  $settings         = undef,
+  ) {
+  include cassandra
+  include stdlib
+
+  if $service_refresh {
+    $notifications = Service['cassandra']
+  } else {
+    $notifications = []
+  }
+
+  if is_hash($file_lines) {
+    $default_file_line = {
+      require => Package['cassandra'],
+      notify  => $notifications,
+    }
+
+    create_resources(file_line, $file_lines, $default_file_line)
+  }
+
+  if is_hash($settings) {
+    file { $config_file:
+      ensure  => present,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      content => template($dse_yaml_tmpl),
+      mode    => $config_file_mode,
+      require => Package['cassandra'],
+      notify  => $notifications,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "locp-cassandra",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "author": "locp",
   "summary": "Installs Cassandra, DataStax Agent & OpsCenter on RHEL/Ubuntu/Debian.",
   "license": "Apache-2.0",

--- a/scripts/beaker_docker.sh
+++ b/scripts/beaker_docker.sh
@@ -21,7 +21,7 @@ fi
 case "$1" in
   connect) port=$( docker ps -n=-1 | grep -v '^CONTAINER' | \
              awk '{ i = NF - 1; print $i }' | sed 's/.*:\(.*\)-.*/\1/' )
-           ssh -v -o GSSAPIAuthentication=no root@localhost -p $port
+           ssh root@localhost -p $port
            ;;
   destroy) docker rm -f $( docker ps -n=-1 -q )
            ;;

--- a/scripts/beaker_docker.sh
+++ b/scripts/beaker_docker.sh
@@ -21,7 +21,7 @@ fi
 case "$1" in
   connect) port=$( docker ps -n=-1 | grep -v '^CONTAINER' | \
              awk '{ i = NF - 1; print $i }' | sed 's/.*:\(.*\)-.*/\1/' )
-           ssh root@localhost -p $port
+           ssh -v -o GSSAPIAuthentication=no root@localhost -p $port
            ;;
   destroy) docker rm -f $( docker ps -n=-1 -q )
            ;;

--- a/scripts/circle.bash
+++ b/scripts/circle.bash
@@ -9,7 +9,7 @@ acceptance_tests () {
   status=0
   BEAKER_set=''
 
-  echo "$CIRCLE_BRANCH" | grep -Eq -e '^release/' -e '^legacy/minor' -e '^legacy/candidate'
+  echo "$CIRCLE_BRANCH" | grep -Eq -e '^release-' -e '^legacy/minor' -e '^legacy/candidate'
 
   if [ $? != 0 ]; then
     echo "Not a release branch."

--- a/spec/acceptance/cassandra_aa020_test_dse_spec.rb
+++ b/spec/acceptance/cassandra_aa020_test_dse_spec.rb
@@ -17,10 +17,6 @@ describe 'cassandra::dse class' do
     it 'should work with no errors' do
       apply_manifest(dse_mock_pp, catch_failures: true)
     end
-    it 'check code is idempotent' do
-      expect(apply_manifest(dse_mock_pp,
-                            catch_failures: true).exit_code).to be_zero
-    end
   end
 
   cassandra_install_pp = <<-EOS

--- a/spec/classes/dse_spec.rb
+++ b/spec/classes/dse_spec.rb
@@ -3,7 +3,7 @@ describe 'cassandra::dse' do
   let(:pre_condition) do
     [
       'class stdlib () {}',
-      'define file_line($line, $path, $match) {}',
+      'define file_line($line, $path, $match) {}'
     ]
   end
 

--- a/spec/classes/dse_spec.rb
+++ b/spec/classes/dse_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+describe 'cassandra::dse' do
+  let(:pre_condition) do
+    [
+      'class stdlib () {}',
+      'define file_line($line, $path, $match) {}',
+    ]
+  end
+
+  context 'with defaults for all parameters' do
+    let :facts do
+      {
+        osfamily: 'RedHat',
+        operatingsystemmajrelease: 7
+      }
+    end
+
+    it do
+      should have_resource_count(11)
+      should contain_class('cassandra')
+
+      should contain_class('cassandra::dse').with(
+        config_file_mode: '0644',
+        config_file: '/etc/dse/dse.yaml'
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,22 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+
+  c.before(:each) do
+    MockFunction.new('concat') do |f|
+      f.stubbed.returns([8888, 22])
+      f.stubbed.with([], '/etc/cassandra')
+       .returns(['/etc/cassandra'])
+      f.stubbed.with([], '/etc/cassandra/default.conf')
+       .returns(['/etc/cassandra/default.conf'])
+      f.stubbed.with(['/etc/cassandra'], '/etc/cassandra/default.conf')
+       .returns(['/etc/cassandra', '/etc/cassandra/default.conf'])
+    end
+
+    MockFunction.new('is_hash') do |f|
+      f.stubbed.with('').returns(false)
+    end
+  end
 end
 
 Coveralls.wear!

--- a/templates/dse.yaml.erb
+++ b/templates/dse.yaml.erb
@@ -1,0 +1,5 @@
+# This file is managed by Puppet.  Manual changes are likely to be
+# overwritten.  If you see that the YAML indentation looks somewhat strange,
+# don't worry, please see the following ticket for more details.
+# https://tickets.puppetlabs.com/browse/PUP-3120
+<%= @settings.to_yaml() %>


### PR DESCRIPTION
This adds the `cassandra::dse class` but also takes out some acceptance testing for `cassandra::opscenter` as the [locp-opscenter](https://forge.puppet.com/locp/opscenter) modules has been available for sometime now.

the documentation (old style) can be previewed at https://github.com/locp/cassandra/tree/release-1.27.0#class-cassandradse and example code at https://github.com/locp/cassandra/tree/release-1.27.0#datastax-enterprise