### PR TITLE
Switch to role management instead of user one

### DIFF
--- a/manifests/schema/user.pp
+++ b/manifests/schema/user.pp
@@ -5,6 +5,7 @@
 #   ensure a user is created, or **absent** to remove the user if it exists.
 # @param password [string] A password for the user.
 # @param superuser [boolean] If the user is to be a super-user on the system.
+# @param login [boolean] True allows the role to log in.
 # @param user_name [string] The name of the user.
 # @example
 #   cassandra::schema::user { 'akers':
@@ -17,27 +18,75 @@
 #   }
 define cassandra::schema::user (
   $ensure    = present,
+  $login     = true,
   $password  = undef,
   $superuser = false,
   $user_name = $title,
   ){
   include 'cassandra::schema'
-  $read_script = 'LIST USERS'
+
+  if $::cassandrarelease != undef {
+    if versioncmp($::cassandrarelease, '2.2') < 0 {
+      $operate_with_roles = false
+    } else {
+      $operate_with_roles = true
+    }
+  } else {
+    $operate_with_roles = false
+  }
+
+  if $operate_with_roles {
+    $read_script = 'LIST ROLES'
+  } else {
+    $read_script = 'LIST USERS'
+  }
   $read_command = "${::cassandra::schema::cqlsh_opts} -e \"${read_script}\" ${::cassandra::schema::cqlsh_conn} | grep '\s*${user_name} |'"
 
   if $ensure == present {
-    $create_script1 = "CREATE USER IF NOT EXISTS ${user_name}"
+    if $operate_with_roles {
+      # we are running cassandra > 2.2
+      $create_script1 = "CREATE ROLE IF NOT EXISTS ${user_name}"
 
-    if $password != undef {
-      $create_script2 = "${create_script1} WITH PASSWORD '${password}'"
-    } else {
-      $create_script2 = $create_script1
-    }
+      if $password != undef {
+        $create_script2 = "${create_script1} WITH PASSWORD = '${password}'"
+      } else {
+        $create_script2 = $create_script1
+      }
 
-    if $superuser {
-      $create_script = "${create_script2} SUPERUSER"
+      if $superuser {
+        if $password != undef {
+          $create_script3 = "${create_script2} AND SUPERUSER = true"
+        } else {
+          $create_script3 = "${create_script2} WITH SUPERUSER = true"
+        }
+      } else {
+        $create_script3 = $create_script2
+      }
+
+      if $login {
+        if $superuser or $password != undef {
+          $create_script = "${create_script3} AND LOGIN = true"
+        }
+        else {
+          $create_script = "${create_script3} WITH LOGIN = true"
+        }
+      } else {
+        $create_script = $create_script3
+      }
     } else {
-      $create_script = "${create_script2} NOSUPERUSER"
+      $create_script1 = "CREATE USER IF NOT EXISTS ${user_name}"
+
+      if $password != undef {
+        $create_script2 = "${create_script1} WITH PASSWORD '${password}'"
+      } else {
+        $create_script2 = $create_script1
+      }
+
+      if $superuser {
+        $create_script = "${create_script2} SUPERUSER"
+      } else {
+        $create_script = "${create_script2} NOSUPERUSER"
+      }
     }
 
     $create_command = "${::cassandra::schema::cqlsh_opts} -e \"${create_script}\" ${::cassandra::schema::cqlsh_conn}"
@@ -48,7 +97,11 @@ define cassandra::schema::user (
       require => Exec['::cassandra::schema connection test'],
     }
   } elsif $ensure == absent {
-    $delete_script = "DROP USER ${user_name}"
+    if $operate_with_roles {
+      $delete_script = "DROP ROLE ${user_name}"
+    } else {
+      $delete_script = "DROP USER ${user_name}"
+    }
     $delete_command = "${::cassandra::schema::cqlsh_opts} -e \"${delete_script}\" ${::cassandra::schema::cqlsh_conn}"
 
     exec { "Delete user (${user_name})":

--- a/spec/defines/schema/user_spec.rb
+++ b/spec/defines/schema/user_spec.rb
@@ -12,11 +12,12 @@ describe 'cassandra::schema::user' do
     ]
   end
 
-  context 'Create a user' do
+  context 'Create a supper user on cassandrarelease undef' do
     let :facts do
       {
         operatingsystemmajrelease: 7,
-        osfamily: 'RedHat'
+        osfamily: 'RedHat',
+        cassandrarelease: nil
       }
     end
 
@@ -37,11 +38,140 @@ describe 'cassandra::schema::user' do
     end
   end
 
-  context 'Drop a user' do
+  context 'Create a supper user in cassandrarelease < 2.2' do
     let :facts do
       {
         operatingsystemmajrelease: 7,
-        osfamily: 'RedHat'
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.1'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        password: 'Niner2',
+        superuser: true
+      }
+    end
+
+    it do
+      should contain_cassandra__schema__user('akers').with_ensure('present')
+      should contain_exec('Create user (akers)').with(
+        command: '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers WITH PASSWORD \'Niner2\' SUPERUSER" localhost 9042'
+      )
+    end
+  end
+
+  context 'Create a user in cassandrarelease < 2.2' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.1'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        password: 'Niner2'
+      }
+    end
+
+    it do
+      should contain_cassandra__schema__user('akers').with_ensure('present')
+      should contain_exec('Create user (akers)').with(
+        command: '/usr/bin/cqlsh   -e "CREATE USER IF NOT EXISTS akers WITH PASSWORD \'Niner2\' NOSUPERUSER" localhost 9042'
+      )
+    end
+  end
+
+  context 'Create a supper user with login in cassandrarelease > 2.2' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        password: 'Niner2',
+        superuser: true
+      }
+    end
+
+    it do
+      should contain_cassandra__schema__user('akers').with_ensure('present')
+      should contain_exec('Create user (akers)').with(
+        command: '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS akers WITH PASSWORD = \'Niner2\' AND SUPERUSER = true AND LOGIN = true" localhost 9042'
+      )
+    end
+  end
+
+  context 'Create a user without login in cassandrarelease > 2.2' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'bob' }
+
+    let(:params) do
+      {
+        password: 'kaZe89a',
+        login: false
+      }
+    end
+
+    it do
+      should contain_cassandra__schema__user('bob').with_ensure('present')
+      should contain_exec('Create user (bob)').with(
+        command: '/usr/bin/cqlsh   -e "CREATE ROLE IF NOT EXISTS bob WITH PASSWORD = \'kaZe89a\'" localhost 9042'
+      )
+    end
+  end
+
+  context 'Drop a user in cassandrarelease > 2.2' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '3.0.9'
+      }
+    end
+
+    let(:title) { 'akers' }
+
+    let(:params) do
+      {
+        password: 'Niner2',
+        ensure: 'absent'
+      }
+    end
+
+    it do
+      should contain_exec('Delete user (akers)').with(
+        command: '/usr/bin/cqlsh   -e "DROP ROLE akers" localhost 9042'
+      )
+    end
+  end
+
+  context 'Drop a user in cassandrarelease < 2.2' do
+    let :facts do
+      {
+        operatingsystemmajrelease: 7,
+        osfamily: 'RedHat',
+        cassandrarelease: '2.0.2'
       }
     end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -371,6 +371,15 @@ class TestManifests
           'spillman' => {
             password => 'Niner27',
           },
+          'bob' => {
+            password => 'kaZe89a',
+            login    => false,
+          },
+          'john' => {
+            superuser => true,
+            password  => 'kaZe89a',
+            login     => true,
+          },
         },
       }
     EOS


### PR DESCRIPTION
CREATE USER, DROP USER, LIST USERS are deprecated in favor of
CREATE ROLE, DROP ROLE, LIST ROLES.
This PR introduces the changes regarding user management by
switching to roles.
CREATE USER is supported for backwards compatibility only.
Authentication and authorization for Cassandra 2.2 and later are
based on ROLES, and use CREATE ROLE instead [1]

[1]. http://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlCreateUser.html